### PR TITLE
Optimized middleware construction.

### DIFF
--- a/example/cmd/main.go
+++ b/example/cmd/main.go
@@ -14,7 +14,10 @@ import (
 func main() {
 	groupService := example.GroupServiceServer{}
 	gw := example.NewGroupServiceGateway(groupService,
-		rpc.WithMiddlewareFunc(Logger),
+		rpc.WithMiddlewareFunc(
+			Logger,
+			Logger2,
+		),
 	)
 
 	go runClientTest()
@@ -42,4 +45,10 @@ func Logger(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
 	fmt.Println("> Hello")
 	next(w, req)
 	fmt.Println("> Goodbye")
+}
+
+func Logger2(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
+	fmt.Println("> Hello 2")
+	next(w, req)
+	fmt.Println("> Goodbye 2")
 }

--- a/rpc/middleware.go
+++ b/rpc/middleware.go
@@ -2,26 +2,53 @@ package rpc
 
 import "net/http"
 
+// WithMiddleware invokes this chain of work before executing the actual HTTP handler for
+// your service call.
+func WithMiddleware(mw ...Middleware) GatewayOption {
+	return func(gw *Gateway) {
+		gw.middleware = mw
+	}
+}
+
+// WithMiddlewareFunc invokes this chain of work before executing the actual HTTP handler for
+// your service call.
+func WithMiddlewareFunc(funcs ...MiddlewareFunc) GatewayOption {
+	mw := make(middlewarePipeline, len(funcs))
+	for i, fn := range funcs {
+		mw[i] = fn
+	}
+	return WithMiddleware(mw...)
+}
+
+// Middleware is a component that conforms to the 'negroni' middleware handler. It accepts the
+// standard HTTP inputs as well as the rest of the computation.
 type Middleware interface {
 	ServeHTTP(w http.ResponseWriter, req *http.Request, next http.HandlerFunc)
 }
 
+// Middleware is a component that conforms to the 'negroni' middleware function. It accepts the
+// standard HTTP inputs as well as the rest of the computation.
 type MiddlewareFunc func(w http.ResponseWriter, req *http.Request, next http.HandlerFunc)
 
+// ServeHTTP basically calls itself. This is a mechanism that lets middleware functions be passed
+// around the same as a full middleware handler component.
 func (mw MiddlewareFunc) ServeHTTP(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
 	mw(w, req, next)
 }
 
-var nopMiddleware MiddlewareFunc = func(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
-	next(w, req)
-}
+// middlewarePipeline is a chain of middleware handlers that fire in succession before ultimately
+// executing the "real" HTTP handler that does the real work for the endpoint.
+type middlewarePipeline []Middleware
 
-func WithMiddleware(mw Middleware) GatewayOption {
-	return func(gw *Gateway) {
-		gw.Middleware = mw
+// Then wraps all of the middleware handlers capped off with the "real work" handler into a single
+// handler function that can be used by a standard net/http server.
+func (pipeline middlewarePipeline) Then(handler http.HandlerFunc) http.HandlerFunc {
+	for i := len(pipeline) - 1; i >= 0; i-- {
+		mw := pipeline[i]
+		next := handler
+		handler = func(res http.ResponseWriter, req *http.Request) {
+			mw.ServeHTTP(res, req, next)
+		}
 	}
-}
-
-func WithMiddlewareFunc(mw MiddlewareFunc) GatewayOption {
-	return WithMiddleware(mw)
+	return handler
 }


### PR DESCRIPTION
Instead of rebuilding the middleware/handler pipeline on every request, we do it once during `NewGateway` setup.