### PR TITLE
Can supply custom URL prefixes.

### DIFF
--- a/example/cmd/main.go
+++ b/example/cmd/main.go
@@ -18,6 +18,7 @@ func main() {
 			Logger,
 			Logger2,
 		),
+		rpc.WithPrefix("v2"),
 	)
 
 	go runClientTest()
@@ -38,6 +39,7 @@ func runClientTest() {
 			ClientLogger,
 			ClientLogger2,
 		),
+		rpc.WithClientPathPrefix("v2"),
 	)
 	response, err := client.GetByID(ctx, &example.GetByIDRequest{
 		ID:   "123x45",
@@ -47,7 +49,7 @@ func runClientTest() {
 }
 
 func Logger(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
-	fmt.Println("> Hello")
+	fmt.Println("> Hello", req.URL.String())
 	next(w, req)
 	fmt.Println("> Goodbye")
 }

--- a/generate/client.go
+++ b/generate/client.go
@@ -31,6 +31,8 @@ func Client(ctx *parser.Context, w io.Writer) error {
 	return nil
 }
 
+// Once Go 1.16 comes out and we can embed files in the Go binary, I should pull this out
+// into a separate template file and just embed that in the binary fs.
 var clientTemplate = template.Must(template.New("gateway").Parse(`// !!!!!!! DO NOT EDIT !!!!!!!
 // Auto-generated client code from {{ .Path }}
 // !!!!!!! DO NOT EDIT !!!!!!!

--- a/generate/gateway.go
+++ b/generate/gateway.go
@@ -33,6 +33,8 @@ func Server(ctx *parser.Context, w io.Writer) error {
 
 //--------------------------------
 
+// Once Go 1.16 comes out and we can embed files in the Go binary, I should pull this out
+// into a separate template file and just embed that in the binary fs.
 var gatewayTemplate = template.Must(template.New("gateway").Parse(`// !!!!!!! DO NOT EDIT !!!!!!!
 // Auto-generated server code from {{.Path}}
 // !!!!!!! DO NOT EDIT !!!!!!!
@@ -53,7 +55,7 @@ func New{{ .Name }}Gateway(service {{ .Name }}, options ...rpc.GatewayOption) rp
 
 	{{ $service := . }}
 	{{ range $service.Methods }}
-	gw.Router.{{ .HTTPMethod }}("{{ .HTTPPath }}", func(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
+	gw.Router.{{ .HTTPMethod }}(gw.PathPrefix + "{{ .HTTPPath }}", func(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
 		response := respond.To(w, req)
 
 		serviceRequest := {{ .Request.Name }}{}


### PR DESCRIPTION
You can supply prefixes like "v2" or "internal/awesome/stuff" when setting up gateways and clients.