### PR TITLE
Models now support type aliases.

### DIFF
--- a/generate/client.go
+++ b/generate/client.go
@@ -21,12 +21,22 @@ import (
 
 {{ $ctx := . }}
 {{ range .Services }}
+// New{{ .Name }}Client creates an RPC client that conforms to the {{ .Name }} interface, but delegates
+// work to remote instances. You must supply the base address of the remote service gateway instance or
+// the load balancer for that service.
+//
+// You should be able to get a working service using default options (i.e. no options), but you can customize
+// the HTTP client, define middleware, and more using client options. All of the ones that apply to the RPC
+// client are named "WithClientXXX()".
 func New{{ .Name }}Client(address string, options ...rpc.ClientOption) *{{ .Name }}Client {
 	return &{{ .Name }}Client{
 		Client: rpc.NewClient("{{ .Name }}", address, options...),
 	}
 }
 
+// {{ .Name }}Client manages all interaction w/ a remote {{ .Name }} instance by letting you invoke functions
+// on this instance as if you were doing it locally (hence... RPC client). You shouldn't instantiate this
+// manually. Instead, you should utilize the New{{ .Name }}Client() function to properly set this up.
 type {{ .Name }}Client struct {
 	rpc.Client
 }
@@ -47,6 +57,13 @@ func (client *{{ $service.Name }}Client) {{ .Name }} (ctx context.Context, reque
 }
 {{ end }}
 
+// {{ .Name }}Proxy fully implements the {{ .Name }} interface, but delegates all operations to a "real"
+// instance of the service. You can embed this type in a struct of your choice so you can "override" or
+// decorate operations as you see fit. Any operations on {{ .Name }} that you don't explicitly define will
+// simply delegate to the default implementation of the underlying 'Service' value.
+//
+// Since you have access to the underlying service, you are able to both implement custom handling logic AND
+// call the "real" implementation, so this can be used as special middleware that applies to only certain operations.
 type {{ .Name }}Proxy struct {
 	Service {{ $ctx.Package.Name }}.{{ .Name }}
 }

--- a/generate/gateway.go
+++ b/generate/gateway.go
@@ -22,8 +22,20 @@ import (
 
 {{ $ctx := . }}
 {{ range .Services }}
+// New{{ .Name }}Gateway accepts your "real" {{ .Name }} instance (the thing that really does the work), and
+// exposes it to other services/clients over RPC. The rpc.Gateway it returns implements http.Handler, so you
+// can pass it to any standard library HTTP server of your choice.
+//
+//	// How to fire up your service for RPC and/or your REST API
+//	service := {{ $ctx.Package.Name }}.{{ .Name }}{ /* set up to your liking */ }
+//	gateway := {{ $ctx.OutputPackage.Name }}.New{{ .Name }}Gateway(service)
+//	http.ListenAndServe(":8080", gateway)
+//
+// The default instance works well enough, but you can supply additional options such as WithMiddleware() which
+// accepts any negroni-compatible middleware handlers.
 func New{{ .Name }}Gateway(service {{ $ctx.Package.Name }}.{{ .Name }}, options ...rpc.GatewayOption) rpc.Gateway {
 	gw := rpc.NewGateway(options...)
+	gw.Name = "{{ .Name }}"
 
 	{{ $service := . }}
 	{{ range $service.Methods }}

--- a/parser/context.go
+++ b/parser/context.go
@@ -15,6 +15,8 @@ type Context struct {
 	File *ast.File
 	// Path is the relative path to the service definition file we're parsing.
 	Path string
+	// AbsolutePath is the absolute path to the service definition file we're parsing.
+	AbsolutePath string
 	// Package contains information about the package where the service definition resides.
 	Package *PackageDeclaration
 	// OutputPackage contains information about the package where the generated code will go.

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -28,8 +28,9 @@ func ParseFile(inputPath string) (*Context, error) {
 	}
 
 	ctx := &Context{
-		File: file,
-		Path: absolutePath,
+		File:         file,
+		Path:         inputPath,
+		AbsolutePath: absolutePath,
 	}
 
 	if err = ParseModuleInfo(ctx); err != nil {
@@ -353,11 +354,15 @@ func IsModelDeclaration(astObj *ast.Object) bool {
 		return false
 	}
 
-	// Your input must be a struct
-	// TODO: support type aliases so you can re-use common inputs/outputs
-	_, ok = typeSpec.Type.(*ast.StructType)
-	if !ok {
+	// The model type must either be a struct or some sort of type alias.
+	switch typeSpec.Type.(type) {
+	case *ast.StructType:
+		return true
+	case *ast.Ident: // type alias to another type in this package (e.g. "type Foo Bar")
+		return true
+	case *ast.SelectorExpr: // type alias to a type in another package (e.g. "type Foo other.Bar")
+		return true
+	default:
 		return false
 	}
-	return true
 }

--- a/rpc/gateway.go
+++ b/rpc/gateway.go
@@ -44,6 +44,7 @@ type GatewayOption func(*Gateway)
 // your service response struct data back to the caller. Aside from feeding this to `http.ListenAndServe()`
 // you likely won't interact with this at all yourself.
 type Gateway struct {
+	Name       string
 	Router     *httprouter.Router
 	Binder     Binder
 	PathPrefix string


### PR DESCRIPTION
Previously, frodo only supported service function params if they were defined in the declarations file as structs:

```go
type GetByIDRequest struct {
    ID string
}
```

With this update, you can define the same type as just a type alias for another type (useful for commonly re-used types):

```go
type GetByIDRequest core.IDRequest
```