### PR TITLE
Supports HTTP redirects (upgraded 'respond' package)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.15
 
 require (
 	github.com/julienschmidt/httprouter v1.3.0
-	github.com/robsignorelli/respond v0.1.0
-	github.com/stretchr/testify v1.6.1
+	github.com/robsignorelli/respond v0.2.0
 	golang.org/x/mod v0.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4d
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/robsignorelli/respond v0.1.0 h1:D5y/SRC0ylDCaYuk3E4GA7fOAjlyEGb2awzPE6BPI+g=
-github.com/robsignorelli/respond v0.1.0/go.mod h1:L4c6fnzgdDO6rTkCTXNd4VU4wwDdjhdNo3oIA0BqxaI=
+github.com/robsignorelli/respond v0.2.0 h1:m7gLgcXNtFIGG2rNNm6WRB/5YpqKsTjruA79KYjkZ5o=
+github.com/robsignorelli/respond v0.2.0/go.mod h1:L4c6fnzgdDO6rTkCTXNd4VU4wwDdjhdNo3oIA0BqxaI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=


### PR DESCRIPTION
I added this support to the `respond` module instead. As a result any service response can implement `respond.Redirector` by implementing the function `Redirect() string` and frodo will not mess with it as it goes through the gateway. Free enhancement. Yay.