### PR TITLE
Generated clients now include function-level comments.

### DIFF
--- a/example/group_service.go
+++ b/example/group_service.go
@@ -6,7 +6,10 @@ import (
 )
 
 type GroupService interface {
-	// GetByID looks up a group given its unique identifier.
+	// GetByID looks up a group given its unique identifier. We will return a NotFoundError
+	// instead of a nil response if there is no record with that id.
+	//
+	// Monkeys are cool.
 	//
 	// GET /group/:id
 	GetByID(ctx context.Context, request *GetByIDRequest) (*GetByIDResponse, error)
@@ -14,8 +17,6 @@ type GroupService interface {
 	// CreateGroup makes a new group... duh.
 	CreateGroup(ctx context.Context, request *CreateGroupRequest) (*CreateGroupResponse, error)
 
-	// DeleteGroup smokes the group if it exists.
-	//
 	// HTTP 202
 	// DELETE /group/:id
 	DeleteGroup(ctx context.Context, request *DeleteGroupRequest) (*DeleteGroupResponse, error)

--- a/generate/client.go
+++ b/generate/client.go
@@ -40,6 +40,8 @@ type {{ .Name }}Client struct {
 
 {{ $service := . }}
 {{ range .Methods }}
+{{ range .Documentation }}
+// {{ . }}{{ end }}
 func (client *{{ $service.Name }}Client) {{ .Name }} (ctx context.Context, request *{{ $ctx.Package.Name }}.{{ .Request.Name }}) (*{{ $ctx.Package.Name }}.{{ .Response.Name }}, error) {
 	if ctx == nil {
 		return nil, fmt.Errorf("precondition failed: nil context")

--- a/generate/javascript.go
+++ b/generate/javascript.go
@@ -28,9 +28,9 @@ class {{ .Name }}Client {
 
     {{ $service := . }}
     {{ range .Methods }}
-    /**
-     * Dispatches the {{ .Name }} REST/RPC request to the service. 
-     * 
+    /**{{ range .Documentation }}
+     * {{ . }} {{ end }}
+     *
      * @param { {{ .Request.Name }} } serviceRequest The input parameters
      * @returns {Promise<{{ .Response.Name }}>} The JSON-encoded return value of the operation.
      */

--- a/parser/context.go
+++ b/parser/context.go
@@ -95,6 +95,8 @@ type ServiceMethodDeclaration struct {
 	HTTPPath string
 	// HTTPStatus indicates what success status code the gateway should use when responding via HTTP (e.g. 200, 202, etc)
 	HTTPStatus int
+	// Documentation are all of the comments documenting this operation.
+	Documentation DocumentationLines
 	// Node is the syntax tree object that defined this function within the service interface.
 	Node *ast.Field
 }
@@ -143,4 +145,35 @@ type PackageDeclaration struct {
 	Import string
 	// Directory is the absolute path to the package.
 	Directory string
+}
+
+// DocumentationLines represents all of the 'go doc' lines above a type/function/field with all
+// of the leading slashes removed.
+type DocumentationLines []string
+
+// Trim removes blank doc lines from the front/back of your list of comments.
+func (docs DocumentationLines) Trim() DocumentationLines {
+	if len(docs) == 0 {
+		return docs
+	}
+	// We want to be able to trim leading and trailing blank lines in a single pass over the
+	// slice, so the first time we encounter a non-empty line that's the first index to keep.
+	// The last index will continuously be updated as we go further and find other non-empty
+	// lines, so by the time we finish the loop we should have both ends of the valid range.
+	first := -1
+	last := -1
+	for i, line := range docs {
+		switch {
+		case line == "":
+			// don't update anything
+		case first < 0:
+			// we just found the first non-blank comment
+			first = i
+			last = i
+		default:
+			// there's another non-blank comment line further after the first one
+			last = i
+		}
+	}
+	return docs[first : last+1]
 }

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -279,8 +279,15 @@ func applyDocCommentOptions(_ *Context, methodObj *ast.Field, method *ServiceMet
 			method.HTTPPath = comment[5:]
 		case strings.HasPrefix(comment, "HTTP "):
 			method.HTTPStatus = parseHTTPStatus(comment[5:])
+		default:
+			method.Documentation = append(method.Documentation, comment)
 		}
 	}
+	fmt.Printf("==BEFORE====\n%v\n==AFTER=====\n%v\n=====",
+		method.Documentation,
+		method.Documentation.Trim(),
+	)
+	method.Documentation = method.Documentation.Trim()
 }
 
 func parseHTTPStatus(statusText string) int {


### PR DESCRIPTION
To make the auto-generated clients play more nicely with IDEs and improve developer experience, the non-option comments you add to service functions are included in the Go/JS clients that frodo generates. This way when a developer uses their IDE to look up "quick documentation" (or their tool's equivalent), they'll be able to see all of the details/quirks about the function call.