### PR TITLE
Added 'errors' package.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,6 @@ require (
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/robsignorelli/respond v0.2.0
 	github.com/spf13/cobra v1.1.1 // indirect
+	github.com/stretchr/testify v1.6.1
 	golang.org/x/mod v0.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,7 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
@@ -161,6 +162,7 @@ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/makefile
+++ b/makefile
@@ -8,7 +8,9 @@ clean-gen:
 
 example-gen: build
 	@ \
-	out/frodoc example/group_service.go
+	out/frodoc gateway --input=example/group_service.go && \
+	out/frodoc client  --input=example/group_service.go --language=go && \
+	out/frodoc client  --input=example/group_service.go --language=js
 
 example-run: example-gen
 	@ \

--- a/rpc/errors/errors.go
+++ b/rpc/errors/errors.go
@@ -1,0 +1,102 @@
+// Package errors provides a curated list of standard types of failures you'll likely
+// encounter when executing RPC handlers. There are almost 40 failure status codes in
+// standard HTTP which leads to a lot of confusion about which to use in certain cases.
+// To simplify this decision making, the errors package only exposes a dozen or so types
+// of failures that we'll map to an appropriate HTTP/RPC status for you. They represent
+// the most common types of failure you're likely to encounter. Should you need something
+// beyond this, the New() function accepts any status you feel like generating.
+package errors
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// RPCError is an error that encodes a human-readable message as well as a
+// status that corresponds to the closest HTTP status code. For instance if the failure
+// was due to an inability to find a resource/record/etc, status would be 404.
+//
+// This type of error can be recognized by 'github.com/robsignorelli/respond' in order to
+// automatically send proper failures and statuses without extra lifting.
+type RPCError struct {
+	// HTTPStatus is the HTTP status code that most closely describes this error.
+	HTTPStatus int `json:"status"`
+	// Message is the human-readable error message.
+	Message string `json:"message"`
+}
+
+// Error returns the underlying error message that describes this failure.
+func (err RPCError) Error() string {
+	return err.Message
+}
+
+// Status returns the most relevant HTTP status code to return for this error.
+func (err RPCError) Status() int {
+	return err.HTTPStatus
+}
+
+// New creates an error that maps directly to an HTTP status so if your RPC call results in
+// this error, it will result in the same 'status' in your HTTP response. While you can do this
+// for more obscure HTTP failure statuses like "payment required", it's typically a better idea
+// to use the error functions BadRequest(), PermissionDenied(), etc as it provides proper status
+// codes and results in more readable code.
+func New(status int, messageFormat string, args ...interface{}) RPCError {
+	return RPCError{
+		HTTPStatus: status,
+		Message:    fmt.Sprintf(messageFormat, args...),
+	}
+}
+
+// InternalServerError is a generic 500-style catch-all error for failures you don't know what to do with.
+func InternalServerError(messageFormat string, args ...interface{}) RPCError {
+	return New(http.StatusInternalServerError, messageFormat, args...)
+}
+
+// BadRequest is a 400-style error that indicates that some aspect of the request was either ill-formed
+// or failed validation. This could be an ill-formed function parameter, a bad HTTP body, etc.
+func BadRequest(messageFormat string, args ...interface{}) RPCError {
+	return New(http.StatusBadRequest, messageFormat, args...)
+}
+
+// BadCredentials is a 401-style error that indicates that the caller either didn't provide credentials
+// when necessary or they did, but the credentials were invalid for some reason. This corresponds to the
+// HTTP "unauthorized" status, but we prefer this name because this type of failure has nothing to do
+// with authorization and it's more clear what aspect of the request has failed.
+func BadCredentials(messageFormat string, args ...interface{}) RPCError {
+	return New(http.StatusUnauthorized, messageFormat, args...)
+}
+
+// PermissionDenied is a 403-style error that indicates that the caller does not have rights/clearance
+// to perform any part of the operation.
+func PermissionDenied(messageFormat string, args ...interface{}) RPCError {
+	return New(http.StatusForbidden, messageFormat, args...)
+}
+
+// NotFound is a 404-style error that indicates that some record/resource could not be located.
+func NotFound(messageFormat string, args ...interface{}) RPCError {
+	return New(http.StatusNotFound, messageFormat, args...)
+}
+
+// Timeout is a 408-style error that indicates that some operation exceeded its allotted time/deadline.
+func Timeout(messageFormat string, args ...interface{}) RPCError {
+	return New(http.StatusRequestTimeout, messageFormat, args...)
+}
+
+// AlreadyExists is a 409-style error that is used when attempting to create some record/resource, but
+// there is already a duplicate instance in existence.
+func AlreadyExists(messageFormat string, args ...interface{}) RPCError {
+	return New(http.StatusConflict, messageFormat, args...)
+}
+
+// Throttled is a 429-style error that indicates that the caller has exceeded the number of requests,
+// amount of resources, etc allowed over some time period. The failure should indicated to the caller
+// that the failure is due to some throttle that prevented the operation from even occurring.
+func Throttled(messageFormat string, args ...interface{}) RPCError {
+	return New(http.StatusTooManyRequests, messageFormat, args...)
+}
+
+// Unavailable is a 503-style error that indicates that some aspect of the server/service is unavailable.
+// This could be something like DB connection failures, some third party service being down, etc.
+func Unavailable(messageFormat string, args ...interface{}) RPCError {
+	return New(http.StatusServiceUnavailable, messageFormat, args...)
+}

--- a/rpc/errors/errors_test.go
+++ b/rpc/errors/errors_test.go
@@ -1,0 +1,100 @@
+package errors_test
+
+import (
+	"testing"
+
+	"github.com/robsignorelli/frodo/rpc/errors"
+	"github.com/stretchr/testify/suite"
+)
+
+type ErrorsSuite struct {
+	suite.Suite
+}
+
+func (suite *ErrorsSuite) TestNew() {
+	suite.assertError(errors.New(100, "foo"), 100, "foo")
+	suite.assertError(errors.New(100, "%s", "foo"), 100, "foo")
+	suite.assertError(errors.New(100, "foo %s %v", "bar", 99), 100, "foo bar 99")
+}
+
+// Since we don't return an error argument for... creating an error... we have no
+// problems with you providing non-HTTP standard errors. Maybe you're doing your own
+// error status mapping; who's to say.
+func (suite *ErrorsSuite) TestNew_wonkyStatus() {
+	suite.assertError(errors.New(0, ""), 0, "")
+	suite.assertError(errors.New(-42, ""), -42, "")
+	suite.assertError(errors.New(9999, ""), 9999, "")
+}
+
+func (suite *ErrorsSuite) TestInternalServerError() {
+	expectedStatus := 500
+	suite.assertError(errors.InternalServerError("foo"), expectedStatus, "foo")
+	suite.assertError(errors.InternalServerError("%s", "foo"), expectedStatus, "foo")
+	suite.assertError(errors.InternalServerError("foo %s %v", "bar", 99), expectedStatus, "foo bar 99")
+}
+
+func (suite *ErrorsSuite) TestBadRequest() {
+	expectedStatus := 400
+	suite.assertError(errors.BadRequest("foo"), expectedStatus, "foo")
+	suite.assertError(errors.BadRequest("%s", "foo"), expectedStatus, "foo")
+	suite.assertError(errors.BadRequest("foo %s %v", "bar", 99), expectedStatus, "foo bar 99")
+}
+
+func (suite *ErrorsSuite) TestBadCredentials() {
+	expectedStatus := 401
+	suite.assertError(errors.BadCredentials("foo"), expectedStatus, "foo")
+	suite.assertError(errors.BadCredentials("%s", "foo"), expectedStatus, "foo")
+	suite.assertError(errors.BadCredentials("foo %s %v", "bar", 99), expectedStatus, "foo bar 99")
+}
+
+func (suite *ErrorsSuite) TestPermissionDenied() {
+	expectedStatus := 403
+	suite.assertError(errors.PermissionDenied("foo"), expectedStatus, "foo")
+	suite.assertError(errors.PermissionDenied("%s", "foo"), expectedStatus, "foo")
+	suite.assertError(errors.PermissionDenied("foo %s %v", "bar", 99), expectedStatus, "foo bar 99")
+}
+
+func (suite *ErrorsSuite) TestNotFound() {
+	expectedStatus := 404
+	suite.assertError(errors.NotFound("foo"), expectedStatus, "foo")
+	suite.assertError(errors.NotFound("%s", "foo"), expectedStatus, "foo")
+	suite.assertError(errors.NotFound("foo %s %v", "bar", 99), expectedStatus, "foo bar 99")
+}
+
+func (suite *ErrorsSuite) TestAlreadyExists() {
+	expectedStatus := 409
+	suite.assertError(errors.AlreadyExists("foo"), expectedStatus, "foo")
+	suite.assertError(errors.AlreadyExists("%s", "foo"), expectedStatus, "foo")
+	suite.assertError(errors.AlreadyExists("foo %s %v", "bar", 99), expectedStatus, "foo bar 99")
+}
+
+func (suite *ErrorsSuite) TestTimeout() {
+	expectedStatus := 408
+	suite.assertError(errors.Timeout("foo"), expectedStatus, "foo")
+	suite.assertError(errors.Timeout("%s", "foo"), expectedStatus, "foo")
+	suite.assertError(errors.Timeout("foo %s %v", "bar", 99), expectedStatus, "foo bar 99")
+}
+
+func (suite *ErrorsSuite) TestThrottled() {
+	expectedStatus := 429
+	suite.assertError(errors.Throttled("foo"), expectedStatus, "foo")
+	suite.assertError(errors.Throttled("%s", "foo"), expectedStatus, "foo")
+	suite.assertError(errors.Throttled("foo %s %v", "bar", 99), expectedStatus, "foo bar 99")
+}
+
+func (suite *ErrorsSuite) TestUnavailable() {
+	expectedStatus := 503
+	suite.assertError(errors.Unavailable("foo"), expectedStatus, "foo")
+	suite.assertError(errors.Unavailable("%s", "foo"), expectedStatus, "foo")
+	suite.assertError(errors.Unavailable("foo %s %v", "bar", 99), expectedStatus, "foo bar 99")
+}
+
+// assertError checks that both the status and message of the resulting 'err' are what we expect.
+func (suite *ErrorsSuite) assertError(err errors.RPCError, expectedStatus int, expectedMessage string) {
+	suite.Require().Equal(expectedStatus, err.Status())
+	suite.Require().Equal(expectedMessage, err.Error())
+}
+
+func TestErrorsSuite(t *testing.T) {
+	suite.Run(t, new(ErrorsSuite))
+}


### PR DESCRIPTION
I've added the `rpc/errors` package so that when your service operations fail, you can do something like `return nil, errors.PermissionDenied("no soup for you")`. The result will be that the generated RPC gateway will respond with a 403 status and contain the message "no soup for you" in the response body.

It allows users to return natural, descriptive errors in their service code and have them transmitted in a meaningful fashion back to callers.