### PR TITLE
Added endpoint information to request context

### DIFF
--- a/example/cmd/main.go
+++ b/example/cmd/main.go
@@ -56,7 +56,7 @@ func Logger(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
 }
 
 func Logger2(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
-	fmt.Println("> Hello 2")
+	fmt.Println("> Hello 2", rpc.EndpointFromContext(req.Context()))
 	next(w, req)
 	fmt.Println("> Goodbye 2")
 }

--- a/example/group_service_server.go
+++ b/example/group_service_server.go
@@ -36,6 +36,5 @@ func (svc GroupServiceServer) CreateGroup(ctx context.Context, req *CreateGroupR
 }
 
 func (svc GroupServiceServer) DeleteGroup(ctx context.Context, req *DeleteGroupRequest) (*DeleteGroupResponse, error) {
-	fmt.Println(">>>>>>> DELETING GROUP:", req.ID, "[", req.Hard, "]")
 	return &DeleteGroupResponse{ID: req.ID, Hard: req.Hard}, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/robsignorelli/frodo
 go 1.15
 
 require (
-	github.com/julienschmidt/httprouter v1.3.0
+	github.com/julienschmidt/httprouter v1.3.1-0.20200921135023-fe77dd05ab5a
 	github.com/robsignorelli/respond v0.2.0
 	github.com/spf13/cobra v1.1.1 // indirect
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/julienschmidt/httprouter v1.3.1-0.20200921135023-fe77dd05ab5a h1:VTF3sHLbpm2PdWMPKVWUMwKg85VE7Ep7wgBw8ETYri8=
+github.com/julienschmidt/httprouter v1.3.1-0.20200921135023-fe77dd05ab5a/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/rpc/gateway.go
+++ b/rpc/gateway.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/robsignorelli/frodo/rpc/metadata"
+	"github.com/robsignorelli/respond"
 )
 
 // NewGateway creates a wrapper around your raw service to expose it via HTTP for RPC calls.
@@ -16,23 +17,36 @@ func NewGateway(options ...GatewayOption) Gateway {
 		Router:     httprouter.New(),
 		Binder:     jsonBinder{},
 		middleware: middlewarePipeline{},
-		PathPrefix: "",
-		handler:    nil,
+		pathPrefix: "",
+		endpoints:  map[string]Endpoint{},
 	}
 	for _, option := range options {
 		option(&gw)
 	}
 
-	// Combine all middleware (internal book-keeping and user-provided) with the handler
-	// for the router/mux to create a single function we'll use as the master handler when
-	// we supply the gateway to ListenAndServe.
+	// Combine all middleware (internal book-keeping and user-provided) into a single pipeline. We
+	// will NOT apply them to the HandlerFunc from the router just yet. We will actually apply these
+	// middlewares to every single endpoint handler inside of Register() rather than once right here.
+	// We need the ROUTER to be the main entry point to your handler so that we can add the Endpoint
+	// data to the request context BEFORE the other middleware fires. If we codified the middleware here
+	// your service handler would have the endpoint data, but not the middleware.
+	//
+	// If we did gw.middleware.Then(gw.Router) here...
+	//
+	//   restoreEndpoint->restoreMetadata->your_middleware->ROUTER->serviceHandler
+	//
+	// By deferring the middleware application until we register the handler with the router we get
+	// the order of operations we want:
+	//
+	//   ROUTER->restoreEndpoint->restoreMetadata->your_middleware->serviceHandler
+	//
+	// Since the router goes first, 'restoreEndpoint' has the info it needs to properly populate the context.
 	mw := middlewarePipeline{
-		MiddlewareFunc(restoreCallDetails),
+		MiddlewareFunc(restoreEndpoint),
 		MiddlewareFunc(restoreMetadata),
 	}
-	mw = append(mw, gw.middleware...)
-	gw.handler = mw.Then(gw.Router.ServeHTTP)
-
+	gw.middleware = append(mw, gw.middleware...)
+	gw.Router.SaveMatchedRoutePath = true
 	return gw
 }
 
@@ -47,14 +61,59 @@ type Gateway struct {
 	Name       string
 	Router     *httprouter.Router
 	Binder     Binder
-	PathPrefix string
+	pathPrefix string
 	middleware middlewarePipeline
-	handler    http.HandlerFunc
+	endpoints  map[string]Endpoint
+}
+
+// Register the operation with the gateway so that it can be exposed for invoking remotely.
+func (gw *Gateway) Register(endpoint Endpoint) {
+	// The user specified a path like "GET /user/:id" in their code, so when they fetch the
+	// endpoint data later, that's what we want it to look like, so we'll leave the endpoint's
+	// Path attribute alone. But... the router needs the full path which includes the optional
+	// prefix (e.g. "/v2"). So we'll use the full path for routing and lookups (transparent to
+	// the user), but the user will never have to see the "/v2" portion.
+	fullPath := gw.pathPrefix + endpoint.Path
+
+	gw.endpoints[fullPath] = endpoint
+	gw.Router.HandlerFunc(endpoint.Method, fullPath, gw.middleware.Then(endpoint.Handler))
 }
 
 // ServeHTTP is the central HTTP handler that includes all http routing, middleware, service forwarding, etc.
 func (gw Gateway) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	gw.handler(w, req)
+	ctx := context.WithValue(req.Context(), contextKeyGateway{}, &gw)
+	gw.Router.ServeHTTP(w, req.WithContext(ctx))
+}
+
+// Endpoint describes an operation that we expose through an RPC gateway.
+type Endpoint struct {
+	// The HTTP method that should be used when exposing this endpoint in the gateway.
+	Method string
+	// The HTTP path pattern that should be used when exposing this endpoint in the gateway.
+	Path string
+	// ServiceName is the name of the service that this operation is part of.
+	ServiceName string
+	// Name is the name of the function/operation that this endpoint describes.
+	Name string
+	// Handler is the gateway function that does the "work".
+	Handler http.HandlerFunc
+}
+
+// String just returns the fully qualified "Service.Operation" descriptor for the operation.
+func (e Endpoint) String() string {
+	return e.ServiceName + "." + e.Name
+}
+
+type contextKeyGateway struct{}
+type contextKeyEndpoint struct{}
+
+// EndpointFromContext fetches the meta information about the service RPC operation that we're currently invoking.
+func EndpointFromContext(ctx context.Context) *Endpoint {
+	endpoint, ok := ctx.Value(contextKeyEndpoint{}).(Endpoint)
+	if !ok {
+		return nil
+	}
+	return &endpoint
 }
 
 // WithPrefix allows you to specify a custom URL prefix for all endpoints. By default a URL might look
@@ -68,18 +127,36 @@ func WithPrefix(pathPrefix string) GatewayOption {
 		case pathPrefix == "/":
 			return
 		case strings.HasPrefix(pathPrefix, "/"):
-			gateway.PathPrefix = pathPrefix
+			gateway.pathPrefix = pathPrefix
 		default:
-			gateway.PathPrefix = "/" + pathPrefix
+			gateway.pathPrefix = "/" + pathPrefix
 		}
 	}
 }
 
-func restoreCallDetails(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
-	ctx := context.WithValue(req.Context(), "ServiceCall", "foo")
+// restoreEndpoint places the *Endpoint data for the current operation onto the request context
+// so your handler can access the RPC details about what is being invoked. Mainly useful for fetching
+// logging/tracing info about the operation.
+func restoreEndpoint(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
+	gw, ok := req.Context().Value(contextKeyGateway{}).(*Gateway)
+	if !ok {
+		respond.To(w, req).InternalServerError("invalid rpc gateway context")
+		return
+	}
+
+	params := httprouter.ParamsFromContext(req.Context())
+	endpoint, ok := gw.endpoints[params.MatchedRoutePath()]
+	if !ok {
+		respond.To(w, req).InternalServerError("no endpoint for path '%s'", params.MatchedRoutePath())
+		return
+	}
+
+	ctx := context.WithValue(req.Context(), contextKeyEndpoint{}, endpoint)
 	next(w, req.WithContext(ctx))
 }
 
+// restoreMetadata parses the "X-RPC-Values" request header and places the values onto the context's metadata
+// so that all shared values from the caller are available for your handler when it's finally invoked.
 func restoreMetadata(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
 	encodedValues := req.Header.Get(metadata.RequestHeader)
 


### PR DESCRIPTION
I added internal book-keeping so that you can fetch meta information about the operation you're invoking. Now, in your service function handler or in middleware you have access to:

```go
endpoint := rpc.EndpointFromContext(ctx)
```
That will give you fully qualified service/function names which are great for logging/tracing.