### PR TITLE
Better CLI error descriptions

### DIFF
--- a/cli/create_service.go
+++ b/cli/create_service.go
@@ -37,9 +37,9 @@ func (c CreateService) Command() *cobra.Command {
 		Short: "Creates a new service in your project with all of the code required to run.",
 		Long:  "This creates a new package in your project for the service. It creates 4 different Go files: your service declaration (interface/structs), your service handler/implementation, the frodo RPC client, and the frodo RPC/API gateway. This also creates a makefile with convenience targets that regenerate your frodo RPC artifacts, build, test, and run your new service.",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: func(cmd *cobra.Command, args []string) {
 			request.ServiceName = args[0]
-			return c.Exec(request)
+			crapPants(c.Exec(request))
 		},
 	}
 	cmd.Flags().StringVar(&request.Directory, "dir", "", "Path to the directory where we'll write the Go file (defaults to new directory named after the service)")

--- a/cli/generate_client.go
+++ b/cli/generate_client.go
@@ -29,9 +29,9 @@ func (c GenerateClient) Command() *cobra.Command {
 		Use:   "client [flags] FILENAME",
 		Short: "Process a Go source file with your service interface to generate an RPC client proxy for your service(s).",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: func(cmd *cobra.Command, args []string) {
 			request.InputFileName = args[0]
-			return c.Exec(request)
+			crapPants(c.Exec(request))
 		},
 	}
 	cmd.Flags().StringVar(&request.Language, "language", "go", "The file extension of the target language (e.g. 'go' or 'js')")

--- a/cli/generate_docs.go
+++ b/cli/generate_docs.go
@@ -25,9 +25,9 @@ func (c GenerateDocs) Command() *cobra.Command {
 		Use:   "docs [flags] FILENAME",
 		Short: "Generates the API documentation for your service that can be distributed to users.",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: func(cmd *cobra.Command, args []string) {
 			request.InputFileName = args[0]
-			return c.Exec(request)
+			crapPants(c.Exec(request))
 		},
 	}
 	cmd.Flags().StringVar(&request.Template, "template", "", "Path to a custom Go template file used to generate this artifact.")

--- a/cli/generate_gateway.go
+++ b/cli/generate_gateway.go
@@ -25,10 +25,12 @@ func (c GenerateGateway) Command() *cobra.Command {
 		Use:   "gateway [flags] FILENAME",
 		Short: "Process a Go source file with your service interface to generate an RPC/API gateway.",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: func(cmd *cobra.Command, args []string) {
 			request.InputFileName = args[0]
-			return c.Exec(request)
+			crapPants(c.Exec(request))
 		},
+		SilenceUsage:  true,
+		SilenceErrors: true,
 	}
 	cmd.Flags().StringVar(&request.Template, "template", "", "Path to a custom Go template file used to generate this artifact.")
 	return cmd
@@ -36,13 +38,13 @@ func (c GenerateGateway) Command() *cobra.Command {
 
 // Exec actually executes the parsing/generating logic creating the gateway for the given declaration.
 func (c GenerateGateway) Exec(request *GenerateGatewayRequest) error {
-	log.Printf("[frodo] Parsing service definitions: %s", request.InputFileName)
+	log.Printf("Parsing service definitions: %s", request.InputFileName)
 	ctx, err := parser.ParseFile(request.InputFileName)
 	if err != nil {
 		return err
 	}
 
 	artifact := request.ToFileTemplate("gateway.go")
-	log.Printf("[frodo] Generating artifact '%s'", artifact.Name)
+	log.Printf("Generating artifact '%s'", artifact.Name)
 	return generate.File(ctx, artifact)
 }

--- a/cli/generate_mock.go
+++ b/cli/generate_mock.go
@@ -25,9 +25,9 @@ func (c GenerateMock) Command() *cobra.Command {
 		Use:   "mock [flags] FILENAME",
 		Short: "Creates a mock instance of your service for unit testing.",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: func(cmd *cobra.Command, args []string) {
 			request.InputFileName = args[0]
-			return c.Exec(request)
+			crapPants(c.Exec(request))
 		},
 	}
 	cmd.Flags().StringVar(&request.Template, "template", "", "Path to a custom Go template file used to generate this artifact.")
@@ -36,7 +36,7 @@ func (c GenerateMock) Command() *cobra.Command {
 
 // Exec takes all of the parsed CLI flags and generates the target mock service artifact.
 func (c GenerateMock) Exec(request *GenerateMockRequest) error {
-	log.Printf("[frodo] Parsing service definitions: %s", request.InputFileName)
+	log.Printf("Parsing service definitions: %s", request.InputFileName)
 	ctx, err := parser.ParseFile(request.InputFileName)
 	if err != nil {
 		return err

--- a/example/names/gen/name_service.gen.client.dart
+++ b/example/names/gen/name_service.gen.client.dart
@@ -268,70 +268,21 @@ class NameServiceException implements Exception {
 }
 
 
-/// SortNameRequest is the input for the SortName function.
-class SortNameRequest implements NameServiceModelJSON { 
-  String? Name;
+/// FirstNameResponse is the output for the FirstName function.
+class FirstNameResponse implements NameServiceModelJSON { 
+  String? FirstName;
 
-  SortNameRequest({ 
-    this.Name,
+  FirstNameResponse({ 
+    this.FirstName,
   });
 
-  SortNameRequest.fromJson(Map<String, dynamic> json) { 
-    Name = json['Name'];
+  FirstNameResponse.fromJson(Map<String, dynamic> json) { 
+    FirstName = json['FirstName'];
   }
 
   Map<String, dynamic> toJson() {
     return { 
-      'Name': Name,
-    };
-  }
-}
-
-/// SortNameResponse is the output for the SortName function.
-class SortNameResponse implements NameServiceModelJSON { 
-  String? SortName;
-
-  SortNameResponse({ 
-    this.SortName,
-  });
-
-  SortNameResponse.fromJson(Map<String, dynamic> json) { 
-    SortName = json['SortName'];
-  }
-
-  Map<String, dynamic> toJson() {
-    return { 
-      'SortName': SortName,
-    };
-  }
-}
-
-/// DownloadResponse is the output for the Download function.
-class DownloadResponse implements NameServiceModelJSON { 
-  Stream<List<int>>? Content;
-  String? ContentType;
-  String? ContentFileName;
-
-  DownloadResponse({ 
-    this.Content,
-    this.ContentType,
-    this.ContentFileName,
-    
-  });
-
-  DownloadResponse.fromJson(Map<String, dynamic> json) { 
-    Content = json['Content'] as Stream<List<int>>?;
-    ContentType = json['ContentType'] ?? 'application/octet-stream';
-    ContentFileName = json['ContentFileName'] ?? '';
-    
-  }
-
-  Map<String, dynamic> toJson() {
-    return { 
-      'Content': _streamToString(Content),
-      'ContentType': ContentType ?? 'application/octet-stream',
-      'ContentFileName': ContentFileName ?? '',
-      
+      'FirstName': FirstName,
     };
   }
 }
@@ -355,86 +306,6 @@ class SplitResponse implements NameServiceModelJSON {
     return { 
       'FirstName': FirstName,
       'LastName': LastName,
-    };
-  }
-}
-
-/// DownloadRequest is the input for the Download function.
-class DownloadRequest implements NameServiceModelJSON { 
-  String? Name;
-
-  DownloadRequest({ 
-    this.Name,
-  });
-
-  DownloadRequest.fromJson(Map<String, dynamic> json) { 
-    Name = json['Name'];
-  }
-
-  Map<String, dynamic> toJson() {
-    return { 
-      'Name': Name,
-    };
-  }
-}
-
-/// FirstNameRequest is the input for the FirstName function.
-class FirstNameRequest implements NameServiceModelJSON { 
-  String? Name;
-
-  FirstNameRequest({ 
-    this.Name,
-  });
-
-  FirstNameRequest.fromJson(Map<String, dynamic> json) { 
-    Name = json['Name'];
-  }
-
-  Map<String, dynamic> toJson() {
-    return { 
-      'Name': Name,
-    };
-  }
-}
-
-/// DownloadExtRequest is the input for the DownloadExt function.
-class DownloadExtRequest implements NameServiceModelJSON { 
-  String? Name;
-  String? Ext;
-
-  DownloadExtRequest({ 
-    this.Name,
-    this.Ext,
-  });
-
-  DownloadExtRequest.fromJson(Map<String, dynamic> json) { 
-    Name = json['Name'];
-    Ext = json['Ext'];
-  }
-
-  Map<String, dynamic> toJson() {
-    return { 
-      'Name': Name,
-      'Ext': Ext,
-    };
-  }
-}
-
-/// LastNameRequest is the output for the LastName function.
-class LastNameRequest implements NameServiceModelJSON { 
-  String? Name;
-
-  LastNameRequest({ 
-    this.Name,
-  });
-
-  LastNameRequest.fromJson(Map<String, dynamic> json) { 
-    Name = json['Name'];
-  }
-
-  Map<String, dynamic> toJson() {
-    return { 
-      'Name': Name,
     };
   }
 }
@@ -477,6 +348,111 @@ class NameRequest implements NameServiceModelJSON {
   }
 }
 
+/// LastNameRequest is the output for the LastName function.
+class LastNameRequest implements NameServiceModelJSON { 
+  String? Name;
+
+  LastNameRequest({ 
+    this.Name,
+  });
+
+  LastNameRequest.fromJson(Map<String, dynamic> json) { 
+    Name = json['Name'];
+  }
+
+  Map<String, dynamic> toJson() {
+    return { 
+      'Name': Name,
+    };
+  }
+}
+
+/// SortNameRequest is the input for the SortName function.
+class SortNameRequest implements NameServiceModelJSON { 
+  String? Name;
+
+  SortNameRequest({ 
+    this.Name,
+  });
+
+  SortNameRequest.fromJson(Map<String, dynamic> json) { 
+    Name = json['Name'];
+  }
+
+  Map<String, dynamic> toJson() {
+    return { 
+      'Name': Name,
+    };
+  }
+}
+
+class SplitRequest implements NameServiceModelJSON { 
+  String? Name;
+
+  SplitRequest({ 
+    this.Name,
+  });
+
+  SplitRequest.fromJson(Map<String, dynamic> json) { 
+    Name = json['Name'];
+  }
+
+  Map<String, dynamic> toJson() {
+    return { 
+      'Name': Name,
+    };
+  }
+}
+
+/// DownloadResponse is the output for the Download function.
+class DownloadResponse implements NameServiceModelJSON { 
+  Stream<List<int>>? Content;
+  String? ContentType;
+  String? ContentFileName;
+
+  DownloadResponse({ 
+    this.Content,
+    this.ContentType,
+    this.ContentFileName,
+    
+  });
+
+  DownloadResponse.fromJson(Map<String, dynamic> json) { 
+    Content = json['Content'] as Stream<List<int>>?;
+    ContentType = json['ContentType'] ?? 'application/octet-stream';
+    ContentFileName = json['ContentFileName'] ?? '';
+    
+  }
+
+  Map<String, dynamic> toJson() {
+    return { 
+      'Content': _streamToString(Content),
+      'ContentType': ContentType ?? 'application/octet-stream',
+      'ContentFileName': ContentFileName ?? '',
+      
+    };
+  }
+}
+
+/// FirstNameRequest is the input for the FirstName function.
+class FirstNameRequest implements NameServiceModelJSON { 
+  String? Name;
+
+  FirstNameRequest({ 
+    this.Name,
+  });
+
+  FirstNameRequest.fromJson(Map<String, dynamic> json) { 
+    Name = json['Name'];
+  }
+
+  Map<String, dynamic> toJson() {
+    return { 
+      'Name': Name,
+    };
+  }
+}
+
 /// DownloadExtResponse is the output for the DownloadExt function.
 class DownloadExtResponse implements NameServiceModelJSON { 
   Stream<List<int>>? Content;
@@ -507,39 +483,63 @@ class DownloadExtResponse implements NameServiceModelJSON {
   }
 }
 
-/// FirstNameResponse is the output for the FirstName function.
-class FirstNameResponse implements NameServiceModelJSON { 
-  String? FirstName;
-
-  FirstNameResponse({ 
-    this.FirstName,
-  });
-
-  FirstNameResponse.fromJson(Map<String, dynamic> json) { 
-    FirstName = json['FirstName'];
-  }
-
-  Map<String, dynamic> toJson() {
-    return { 
-      'FirstName': FirstName,
-    };
-  }
-}
-
-class SplitRequest implements NameServiceModelJSON { 
+/// DownloadRequest is the input for the Download function.
+class DownloadRequest implements NameServiceModelJSON { 
   String? Name;
 
-  SplitRequest({ 
+  DownloadRequest({ 
     this.Name,
   });
 
-  SplitRequest.fromJson(Map<String, dynamic> json) { 
+  DownloadRequest.fromJson(Map<String, dynamic> json) { 
     Name = json['Name'];
   }
 
   Map<String, dynamic> toJson() {
     return { 
       'Name': Name,
+    };
+  }
+}
+
+/// DownloadExtRequest is the input for the DownloadExt function.
+class DownloadExtRequest implements NameServiceModelJSON { 
+  String? Name;
+  String? Ext;
+
+  DownloadExtRequest({ 
+    this.Name,
+    this.Ext,
+  });
+
+  DownloadExtRequest.fromJson(Map<String, dynamic> json) { 
+    Name = json['Name'];
+    Ext = json['Ext'];
+  }
+
+  Map<String, dynamic> toJson() {
+    return { 
+      'Name': Name,
+      'Ext': Ext,
+    };
+  }
+}
+
+/// SortNameResponse is the output for the SortName function.
+class SortNameResponse implements NameServiceModelJSON { 
+  String? SortName;
+
+  SortNameResponse({ 
+    this.SortName,
+  });
+
+  SortNameResponse.fromJson(Map<String, dynamic> json) { 
+    SortName = json['SortName'];
+  }
+
+  Map<String, dynamic> toJson() {
+    return { 
+      'SortName': SortName,
     };
   }
 }

--- a/example/names/gen/name_service.gen.client.js
+++ b/example/names/gen/name_service.gen.client.js
@@ -482,39 +482,28 @@ class GatewayError {
 
 
 /**
- * @typedef { object } SortNameResponse
- * @property { string } [SortName]
+ * @typedef { object } DownloadExtResponse
 */
 /**
- * @typedef { object } LastNameResponse
- * @property { string } [LastName]
-*/
-/**
- * @typedef { object } NameRequest
+ * @typedef { object } DownloadExtRequest
  * @property { string } [Name]
-*/
-/**
- * @typedef { object } DownloadRequest
- * @property { string } [Name]
+ * @property { string } [Ext]
 */
 /**
  * @typedef { object } LastNameRequest
  * @property { string } [Name]
 */
 /**
- * @typedef { object } DownloadExtResponse
+ * @typedef { object } LastNameResponse
+ * @property { string } [LastName]
 */
 /**
- * @typedef { object } FirstNameRequest
- * @property { string } [Name]
+ * @typedef { object } SortNameResponse
+ * @property { string } [SortName]
 */
 /**
  * @typedef { object } FirstNameResponse
  * @property { string } [FirstName]
-*/
-/**
- * @typedef { object } SortNameRequest
- * @property { string } [Name]
 */
 /**
  * @typedef { object } SplitResponse
@@ -522,16 +511,27 @@ class GatewayError {
  * @property { string } [LastName]
 */
 /**
- * @typedef { object } DownloadResponse
+ * @typedef { object } FirstNameRequest
+ * @property { string } [Name]
+*/
+/**
+ * @typedef { object } NameRequest
+ * @property { string } [Name]
 */
 /**
  * @typedef { object } SplitRequest
  * @property { string } [Name]
 */
 /**
- * @typedef { object } DownloadExtRequest
+ * @typedef { object } DownloadRequest
  * @property { string } [Name]
- * @property { string } [Ext]
+*/
+/**
+ * @typedef { object } SortNameRequest
+ * @property { string } [Name]
+*/
+/**
+ * @typedef { object } DownloadResponse
 */
 
 module.exports = {

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/monadicstack/frodo/cli"
@@ -19,6 +20,7 @@ func main() {
 	rootCmd.AddCommand(cli.GenerateDocs{}.Command())
 	rootCmd.AddCommand(cli.CreateService{}.Command())
 
+	log.SetFlags(0)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/makefile
+++ b/makefile
@@ -7,6 +7,11 @@ build:
 	@ \
 	go build -o out/frodo main.go
 
+install: build
+	@ \
+ 	echo "Overwriting go-installed version..." && \
+ 	cp out/frodo $$GOPATH/bin/frodo
+
 #
 # Uses the frodo CLI to build the gateway and clients used in our test suites to validate code generation. This will
 # build the frodo tool locally and use that rather than using the 'go install'-ed one to ensure we're testing the

--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -231,7 +231,7 @@ func (suite *ParserSuite) TestErrorNoServices() {
 func (suite *ParserSuite) TestErrorFunctionParams() {
 	_, err := parser.ParseFile("testdata/errors/paramcount/service.go")
 	suite.Require().Error(err, "Should fail when a function does not have 2 params")
-	suite.Require().Contains(err.Error(), "2", "Error should include the required parameter count")
+	suite.Require().Contains(err.Error(), "two", "Error should include the required parameter count")
 
 	_, err = parser.ParseFile("testdata/errors/contextparam/service.go")
 	suite.Require().Error(err, "Should fail when a function's first arg is not a Context")
@@ -249,7 +249,7 @@ func (suite *ParserSuite) TestErrorFunctionParams() {
 func (suite *ParserSuite) TestErrorResponseNotStruct() {
 	_, err := parser.ParseFile("testdata/errors/resultcount/service.go")
 	suite.Require().Error(err, "Should fail when a function does not have 2 return values")
-	suite.Require().Contains(err.Error(), "2", "Error should include the required return value count")
+	suite.Require().Contains(err.Error(), "two", "Error should include the required return value count")
 
 	_, err = parser.ParseFile("testdata/errors/resnotpointer/service.go")
 	suite.Require().Error(err, "Should fail when a function's first return value is not a pointer")


### PR DESCRIPTION
Per the suggestions and discussion in issue #47, when the CLI fails because you didn't define your service correctly, the `frodo` tool actually outputs helpful instructions about what to fix in your code. There is better detail for:

* You didn't define services correctly
* You defined multiple services in a single file
* One of your methods has an invalid signature
* You aren't using Go Modules