### PR TITLE
Binder properly handles embedded struct attributes.

### DIFF
--- a/example/names/gen/name_service.gen.client.dart
+++ b/example/names/gen/name_service.gen.client.dart
@@ -268,44 +268,21 @@ class NameServiceException implements Exception {
 }
 
 
-/// FirstNameResponse is the output for the FirstName function.
-class FirstNameResponse implements NameServiceModelJSON { 
-  String? FirstName;
+/// LastNameRequest is the output for the LastName function.
+class LastNameRequest implements NameServiceModelJSON { 
+  String? Name;
 
-  FirstNameResponse({ 
-    this.FirstName,
+  LastNameRequest({ 
+    this.Name,
   });
 
-  FirstNameResponse.fromJson(Map<String, dynamic> json) { 
-    FirstName = json['FirstName'];
+  LastNameRequest.fromJson(Map<String, dynamic> json) { 
+    Name = json['Name'];
   }
 
   Map<String, dynamic> toJson() {
     return { 
-      'FirstName': FirstName,
-    };
-  }
-}
-
-/// SplitResponse is the output for the Split function.
-class SplitResponse implements NameServiceModelJSON { 
-  String? FirstName;
-  String? LastName;
-
-  SplitResponse({ 
-    this.FirstName,
-    this.LastName,
-  });
-
-  SplitResponse.fromJson(Map<String, dynamic> json) { 
-    FirstName = json['FirstName'];
-    LastName = json['LastName'];
-  }
-
-  Map<String, dynamic> toJson() {
-    return { 
-      'FirstName': FirstName,
-      'LastName': LastName,
+      'Name': Name,
     };
   }
 }
@@ -329,77 +306,25 @@ class LastNameResponse implements NameServiceModelJSON {
   }
 }
 
-/// NameRequest generalizes the data we pass to any of the name service functions.
-class NameRequest implements NameServiceModelJSON { 
+/// DownloadExtRequest is the input for the DownloadExt function.
+class DownloadExtRequest implements NameServiceModelJSON { 
   String? Name;
+  String? Ext;
 
-  NameRequest({ 
+  DownloadExtRequest({ 
     this.Name,
+    this.Ext,
   });
 
-  NameRequest.fromJson(Map<String, dynamic> json) { 
+  DownloadExtRequest.fromJson(Map<String, dynamic> json) { 
     Name = json['Name'];
+    Ext = json['Ext'];
   }
 
   Map<String, dynamic> toJson() {
     return { 
       'Name': Name,
-    };
-  }
-}
-
-/// LastNameRequest is the output for the LastName function.
-class LastNameRequest implements NameServiceModelJSON { 
-  String? Name;
-
-  LastNameRequest({ 
-    this.Name,
-  });
-
-  LastNameRequest.fromJson(Map<String, dynamic> json) { 
-    Name = json['Name'];
-  }
-
-  Map<String, dynamic> toJson() {
-    return { 
-      'Name': Name,
-    };
-  }
-}
-
-/// SortNameRequest is the input for the SortName function.
-class SortNameRequest implements NameServiceModelJSON { 
-  String? Name;
-
-  SortNameRequest({ 
-    this.Name,
-  });
-
-  SortNameRequest.fromJson(Map<String, dynamic> json) { 
-    Name = json['Name'];
-  }
-
-  Map<String, dynamic> toJson() {
-    return { 
-      'Name': Name,
-    };
-  }
-}
-
-class SplitRequest implements NameServiceModelJSON { 
-  String? Name;
-
-  SplitRequest({ 
-    this.Name,
-  });
-
-  SplitRequest.fromJson(Map<String, dynamic> json) { 
-    Name = json['Name'];
-  }
-
-  Map<String, dynamic> toJson() {
-    return { 
-      'Name': Name,
+      'Ext': Ext,
     };
   }
 }
@@ -418,6 +343,36 @@ class DownloadResponse implements NameServiceModelJSON {
   });
 
   DownloadResponse.fromJson(Map<String, dynamic> json) { 
+    Content = json['Content'] as Stream<List<int>>?;
+    ContentType = json['ContentType'] ?? 'application/octet-stream';
+    ContentFileName = json['ContentFileName'] ?? '';
+    
+  }
+
+  Map<String, dynamic> toJson() {
+    return { 
+      'Content': _streamToString(Content),
+      'ContentType': ContentType ?? 'application/octet-stream',
+      'ContentFileName': ContentFileName ?? '',
+      
+    };
+  }
+}
+
+/// DownloadExtResponse is the output for the DownloadExt function.
+class DownloadExtResponse implements NameServiceModelJSON { 
+  Stream<List<int>>? Content;
+  String? ContentType;
+  String? ContentFileName;
+
+  DownloadExtResponse({ 
+    this.Content,
+    this.ContentType,
+    this.ContentFileName,
+    
+  });
+
+  DownloadExtResponse.fromJson(Map<String, dynamic> json) { 
     Content = json['Content'] as Stream<List<int>>?;
     ContentType = json['ContentType'] ?? 'application/octet-stream';
     ContentFileName = json['ContentFileName'] ?? '';
@@ -453,45 +408,15 @@ class FirstNameRequest implements NameServiceModelJSON {
   }
 }
 
-/// DownloadExtResponse is the output for the DownloadExt function.
-class DownloadExtResponse implements NameServiceModelJSON { 
-  Stream<List<int>>? Content;
-  String? ContentType;
-  String? ContentFileName;
-
-  DownloadExtResponse({ 
-    this.Content,
-    this.ContentType,
-    this.ContentFileName,
-    
-  });
-
-  DownloadExtResponse.fromJson(Map<String, dynamic> json) { 
-    Content = json['Content'] as Stream<List<int>>?;
-    ContentType = json['ContentType'] ?? 'application/octet-stream';
-    ContentFileName = json['ContentFileName'] ?? '';
-    
-  }
-
-  Map<String, dynamic> toJson() {
-    return { 
-      'Content': _streamToString(Content),
-      'ContentType': ContentType ?? 'application/octet-stream',
-      'ContentFileName': ContentFileName ?? '',
-      
-    };
-  }
-}
-
-/// DownloadRequest is the input for the Download function.
-class DownloadRequest implements NameServiceModelJSON { 
+/// SortNameRequest is the input for the SortName function.
+class SortNameRequest implements NameServiceModelJSON { 
   String? Name;
 
-  DownloadRequest({ 
+  SortNameRequest({ 
     this.Name,
   });
 
-  DownloadRequest.fromJson(Map<String, dynamic> json) { 
+  SortNameRequest.fromJson(Map<String, dynamic> json) { 
     Name = json['Name'];
   }
 
@@ -502,25 +427,63 @@ class DownloadRequest implements NameServiceModelJSON {
   }
 }
 
-/// DownloadExtRequest is the input for the DownloadExt function.
-class DownloadExtRequest implements NameServiceModelJSON { 
-  String? Name;
-  String? Ext;
+/// SplitResponse is the output for the Split function.
+class SplitResponse implements NameServiceModelJSON { 
+  String? FirstName;
+  String? LastName;
 
-  DownloadExtRequest({ 
-    this.Name,
-    this.Ext,
+  SplitResponse({ 
+    this.FirstName,
+    this.LastName,
   });
 
-  DownloadExtRequest.fromJson(Map<String, dynamic> json) { 
+  SplitResponse.fromJson(Map<String, dynamic> json) { 
+    FirstName = json['FirstName'];
+    LastName = json['LastName'];
+  }
+
+  Map<String, dynamic> toJson() {
+    return { 
+      'FirstName': FirstName,
+      'LastName': LastName,
+    };
+  }
+}
+
+/// NameRequest generalizes the data we pass to any of the name service functions.
+class NameRequest implements NameServiceModelJSON { 
+  String? Name;
+
+  NameRequest({ 
+    this.Name,
+  });
+
+  NameRequest.fromJson(Map<String, dynamic> json) { 
     Name = json['Name'];
-    Ext = json['Ext'];
   }
 
   Map<String, dynamic> toJson() {
     return { 
       'Name': Name,
-      'Ext': Ext,
+    };
+  }
+}
+
+/// FirstNameResponse is the output for the FirstName function.
+class FirstNameResponse implements NameServiceModelJSON { 
+  String? FirstName;
+
+  FirstNameResponse({ 
+    this.FirstName,
+  });
+
+  FirstNameResponse.fromJson(Map<String, dynamic> json) { 
+    FirstName = json['FirstName'];
+  }
+
+  Map<String, dynamic> toJson() {
+    return { 
+      'FirstName': FirstName,
     };
   }
 }
@@ -540,6 +503,43 @@ class SortNameResponse implements NameServiceModelJSON {
   Map<String, dynamic> toJson() {
     return { 
       'SortName': SortName,
+    };
+  }
+}
+
+class SplitRequest implements NameServiceModelJSON { 
+  String? Name;
+
+  SplitRequest({ 
+    this.Name,
+  });
+
+  SplitRequest.fromJson(Map<String, dynamic> json) { 
+    Name = json['Name'];
+  }
+
+  Map<String, dynamic> toJson() {
+    return { 
+      'Name': Name,
+    };
+  }
+}
+
+/// DownloadRequest is the input for the Download function.
+class DownloadRequest implements NameServiceModelJSON { 
+  String? Name;
+
+  DownloadRequest({ 
+    this.Name,
+  });
+
+  DownloadRequest.fromJson(Map<String, dynamic> json) { 
+    Name = json['Name'];
+  }
+
+  Map<String, dynamic> toJson() {
+    return { 
+      'Name': Name,
     };
   }
 }

--- a/example/names/gen/name_service.gen.client.js
+++ b/example/names/gen/name_service.gen.client.js
@@ -482,28 +482,23 @@ class GatewayError {
 
 
 /**
- * @typedef { object } DownloadExtResponse
+ * @typedef { object } FirstNameRequest
+ * @property { string } [Name]
 */
 /**
- * @typedef { object } DownloadExtRequest
- * @property { string } [Name]
- * @property { string } [Ext]
+ * @typedef { object } DownloadResponse
+*/
+/**
+ * @typedef { object } FirstNameResponse
+ * @property { string } [FirstName]
 */
 /**
  * @typedef { object } LastNameRequest
  * @property { string } [Name]
 */
 /**
- * @typedef { object } LastNameResponse
- * @property { string } [LastName]
-*/
-/**
  * @typedef { object } SortNameResponse
  * @property { string } [SortName]
-*/
-/**
- * @typedef { object } FirstNameResponse
- * @property { string } [FirstName]
 */
 /**
  * @typedef { object } SplitResponse
@@ -511,27 +506,32 @@ class GatewayError {
  * @property { string } [LastName]
 */
 /**
- * @typedef { object } FirstNameRequest
+ * @typedef { object } DownloadRequest
  * @property { string } [Name]
+*/
+/**
+ * @typedef { object } DownloadExtRequest
+ * @property { string } [Name]
+ * @property { string } [Ext]
 */
 /**
  * @typedef { object } NameRequest
  * @property { string } [Name]
 */
 /**
- * @typedef { object } SplitRequest
- * @property { string } [Name]
+ * @typedef { object } LastNameResponse
+ * @property { string } [LastName]
 */
 /**
- * @typedef { object } DownloadRequest
- * @property { string } [Name]
+ * @typedef { object } DownloadExtResponse
 */
 /**
  * @typedef { object } SortNameRequest
  * @property { string } [Name]
 */
 /**
- * @typedef { object } DownloadResponse
+ * @typedef { object } SplitRequest
+ * @property { string } [Name]
 */
 
 module.exports = {

--- a/internal/reflection/reflection.go
+++ b/internal/reflection/reflection.go
@@ -82,7 +82,7 @@ func (attrs StructAttributes) Remove(name string) StructAttributes {
 // StructAttribute represents a single key/value pair for a field on a struct.
 type StructAttribute struct {
 	// Name is the binding name of the struct value. If there was a JSON tag on the
-	// struct field, it should be that value. Otherwise it's just the struct field's name.
+	// struct field, it should be that value. Otherwise, it's just the struct field's name.
 	Name string
 	// Value is the runtime value of this field on the struct you ran through "ToAttributes()"
 	Value interface{}
@@ -104,6 +104,12 @@ func FindField(structType reflect.Type, name string) (reflect.StructField, bool)
 		field := structType.Field(i)
 		if strings.EqualFold(name, BindingName(field)) {
 			return field, true
+		}
+		if !field.Anonymous {
+			continue
+		}
+		if embeddedField, ok := FindField(field.Type, name); ok {
+			return embeddedField, ok
 		}
 	}
 	return noField, false
@@ -138,7 +144,7 @@ func BindingName(field reflect.StructField) string {
 	}
 }
 
-// Assign simply performs a reflective replace of the value, making sure to try to properly handle pointers.
+// Assign simply performs a reflective replacement of the value, making sure to try to properly handle pointers.
 func Assign(value interface{}, out interface{}) bool {
 	// Depending on whether you wrote "SomeStruct{}" or "&SomeStruct{}" (a pointer) to the
 	// scope, we want to make sure that we're de-referencing the scope value properly.

--- a/rpc/binding.go
+++ b/rpc/binding.go
@@ -54,8 +54,8 @@ func WithBinder(binder Binder) GatewayOption {
 // JSON marshaling rules will overlay each one onto your 'out' value.
 type jsonBinder struct{}
 
-// jsonBindingContext carries our buffer/decoder context through all of the binding operations so
-// that all values can share resources (e.g. binding the path params can piggy back off of the
+// jsonBindingContext carries our buffer/decoder context through all the binding operations so
+// that all values can share resources (e.g. binding the path params can piggy-back off of the
 // work of binding the query string).
 type jsonBindingContext struct {
 	buf     *bytes.Buffer
@@ -102,7 +102,7 @@ func (b jsonBinder) BindBody(_ jsonBindingContext, req *http.Request, out interf
 	return json.NewDecoder(req.Body).Decode(out)
 }
 
-// BindQueryString decodes all of the query string parameters onto the 'out' value. Each parameter will
+// BindQueryString decodes the query string parameters onto the 'out' value. Each parameter will
 // be converted to an equivalent JSON object and unmarshaled separately.
 func (b jsonBinder) BindQueryString(ctx jsonBindingContext, req *http.Request, out interface{}) error {
 	if req.URL == nil {
@@ -111,7 +111,7 @@ func (b jsonBinder) BindQueryString(ctx jsonBindingContext, req *http.Request, o
 	return b.bindValues(ctx, req.URL.Query(), out)
 }
 
-// BindQueryString decodes all of the URL path parameters onto the 'out' value. Each parameter will
+// BindPathParams decodes the URL path parameters onto the 'out' value. Each parameter will
 // be converted to an equivalent JSON object and unmarshaled separately.
 func (b jsonBinder) BindPathParams(ctx jsonBindingContext, req *http.Request, out interface{}) error {
 	params := httptreemux.ContextParams(req.Context())
@@ -140,7 +140,7 @@ func (b jsonBinder) bindValues(ctx jsonBindingContext, requestValues url.Values,
 		if valueType == jsonTypeNil {
 			continue
 		}
-		// Maybe you provided "foo.bar.baz=4" and there was is a field at "out.foo.bar.baz", but it's
+		// Maybe you provided "foo.bar.baz=4" and there is a field at "out.foo.bar.baz", but it's
 		// a struct of some kind, so "4" is not enough to properly bind it. Arrays/slices we'll handle
 		// in a future version... maybe.
 		if valueType == jsonTypeObject || valueType == jsonTypeArray {
@@ -189,13 +189,13 @@ func (b jsonBinder) writeBindingValueJSON(buf *bytes.Buffer, value string, value
 	case jsonTypeNumber, jsonTypeBool:
 		buf.WriteString(value)
 	default:
-		// Whether its a nil (unknown) or object type, the binder doesn't support that type
+		// Whether it's a nil (unknown) or object type, the binder doesn't support that type
 		// of value, so just write null to avoid binding anything if we can help it.
 		buf.WriteString("null")
 	}
 }
 
-// jsonType describes all of the possible JSON data types.
+// jsonType describes all possible JSON data types.
 type jsonType int
 
 const (
@@ -222,7 +222,7 @@ func (b jsonBinder) keyToJSONType(outValue reflect.Value, key []string, value st
 
 	// Follow the path of attributes described by the key, so if the key was "foo.bar.baz" then look up
 	// "foo" on the out value, then the "bar" attribute on that type, then the "baz" attribute on that type.
-	// Once we exit the loop, 'actualType' should be the type of that nested "baz" field and we can
+	// Once we exit the loop, 'actualType' should be the type of that nested "baz" field, and we can
 	// determine the correct JSON type from there.
 	actualType := reflection.FlattenPointerType(outValue.Type())
 	for i := 0; i < keyLength; i++ {
@@ -234,7 +234,7 @@ func (b jsonBinder) keyToJSONType(outValue reflect.Value, key []string, value st
 	}
 
 	// Now that we have the Go type for the field that will ultimately be populated by this parameter/value,
-	// we need to do a quick double check. The field's Go type might be some type alias for an int64 so the
+	// we need to do a quick double check. The field's Go type might be a type alias for an int64 so the
 	// natural choice for a JSON binding would be to use a number (which is what 't' will resolve to).
 	//
 	// But... what if the user provided the value "5m2s" for that field? If we blindly treat the value like
@@ -250,7 +250,7 @@ func (b jsonBinder) keyToJSONType(outValue reflect.Value, key []string, value st
 	// such as "PT3M49S". By looking at the Go type you'd think that the incoming param value should be a
 	// JSON number (since the duration is an int64), but the value doesn't "look" like a number; it looks
 	// like a freeform string. As a result, we need to build the binding JSON {"foo":"PT3M49S"} since we will
-	// treat the right hand side as a string rather than {"foo":PT3M48S} which is not valid.
+	// treat the right-hand side as a string rather than {"foo":PT3M48S} which is not valid.
 	t := b.typeToJSONType(actualType)
 	if t == jsonTypeBool && !b.looksLikeBoolJSON(value) {
 		return jsonTypeString
@@ -291,7 +291,7 @@ func (b jsonBinder) looksLikeBoolJSON(value string) bool {
 }
 
 // looksLikeNumberJSON determines if the raw parameter value looks like it can be formatted as a JSON
-// number. Basically, does it only contain digits and a decimal point. Currently this only supports using
+// number. Basically, does it only contain digits and a decimal point. Currently, this only supports using
 // periods as decimal points. A future iteration might support using /x/text/language to support commas
 // as decimals points.
 func (b jsonBinder) looksLikeNumberJSON(value string) bool {

--- a/rpc/binding_test.go
+++ b/rpc/binding_test.go
@@ -282,6 +282,50 @@ func (suite *BindingSuite) TestBind_errors() {
 	suite.Error(err, "Should return an error when URL is nil")
 }
 
+// This ensures that our binder accepts the short-form JSON for embedded structs/attributes. In this case, if you
+// are trying to set "serviceRequest.EmbeddedID.ID" you need to have the param "ID" and not "EmbeddedID.ID" so that
+// we match the semantics of the standard library.
+func (suite *BindingSuite) TestBind_embeddedStruct() {
+	req := suite.newRequest("PATCH", noBody, noQuery, bindingValues{"ID": "abcdef", "Total": "99"})
+	result, err := suite.bind(req)
+	suite.NoError(err)
+	suite.Equal("abcdef", result.EmbeddedID.ID, "Path params should be able to set embedded struct attributes.")
+	suite.Equal(99, result.EmbeddedID.Total, "Path params should be able to set embedded struct attributes.")
+
+	req = suite.newRequest("PATCH", noBody, bindingValues{"ID": "abcdef", "Total": "99"}, noPathParams)
+	result, err = suite.bind(req)
+	suite.NoError(err)
+	suite.Equal("abcdef", result.EmbeddedID.ID, "Query params should be able to set embedded struct attributes.")
+	suite.Equal(99, result.EmbeddedID.Total, "Path params should be able to set embedded struct attributes.")
+
+	req = suite.newRequest("PATCH", `{"ID": "abcdef", "Total": 99}`, noQuery, noPathParams)
+	result, err = suite.bind(req)
+	suite.NoError(err)
+	suite.Equal("abcdef", result.EmbeddedID.ID, "Body should be able to set embedded struct attributes.")
+	suite.Equal(99, result.EmbeddedID.Total, "Path params should be able to set embedded struct attributes.")
+}
+
+// This ensures that the binder adheres to standard JSON decoding rules. If you have an embedded struct, you
+// need to use the sugar-coated form of the attribute rather than the full one. In this case, if you're trying to
+// set "serviceRequest.EmbeddedID.ID", your params should include "ID=123" and not "EmbeddedID.ID=123". I think
+// its silly that both are not supported, but that's how the standard library handles JSON, so that's how we do it.
+func (suite *BindingSuite) TestBind_embeddedStructNoLongForm() {
+	req := suite.newRequest("PATCH", noBody, noQuery, bindingValues{"EmbeddedID.ID": "abcdef"})
+	result, err := suite.bind(req)
+	suite.NoError(err)
+	suite.Equal("", result.EmbeddedID.ID, "Embedded struct attributes should be flattened (e.g. Embedded.Name -> Name)")
+
+	req = suite.newRequest("PATCH", noBody, bindingValues{"EmbeddedID.ID": "abcdef"}, noPathParams)
+	result, err = suite.bind(req)
+	suite.NoError(err)
+	suite.Equal("", result.EmbeddedID.ID, "Embedded struct attributes should be flattened (e.g. Embedded.Name -> Name)")
+
+	req = suite.newRequest("PATCH", `{"EmbeddedID.ID": "abcdef"}`, noQuery, noPathParams)
+	result, err = suite.bind(req)
+	suite.NoError(err)
+	suite.Equal("", result.EmbeddedID.ID, "Embedded struct attributes should be flattened (e.g. Embedded.Name -> Name)")
+}
+
 // Ensures that we can use functional options to set the binder when setting up a gateway.
 func (suite *BindingSuite) TestWithBinder() {
 	gateway := rpc.NewGateway(rpc.WithBinder(nil))
@@ -333,8 +377,10 @@ func parseTime(value string) time.Time {
 	return t
 }
 
-// serviceRequest contains all of the different types of fields we want to try binding.
+// serviceRequest contains all the different types of fields we want to try binding.
 type serviceRequest struct {
+	EmbeddedID
+
 	String    string
 	StringPtr *string
 	Int       int
@@ -362,6 +408,12 @@ type serviceRequest struct {
 	StringSlice []string
 	StringMap   map[string]string
 	ChanInt     chan int
+}
+
+// EmbeddedID contains... an ID... that can be embedded in a struct.
+type EmbeddedID struct {
+	ID    string
+	Total int
 }
 
 type searchCriteria struct {


### PR DESCRIPTION
This addresses issue #52

When we look for the JSON type of an attribute, we recursively iterated the fields of the binding struct looking for the parameter name. I wasn't looking at the fields of embedded structs for that name like I should have been. The helper `reflection.FindField()` is now recursive and will look at embedded fields for the target field as well.