### PR TITLE
#62 Additional error helpers

### DIFF
--- a/rpc/errors/errors.go
+++ b/rpc/errors/errors.go
@@ -8,6 +8,7 @@
 package errors
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 )
@@ -35,6 +36,18 @@ func (err RPCError) Status() int {
 	return err.HTTPStatus
 }
 
+type errorWithStatus interface {
+	Status() int
+}
+
+type errorWithStatusCode interface {
+	StatusCode() int
+}
+
+type errorWithCode interface {
+	Code() int
+}
+
 // New creates an error that maps directly to an HTTP status so if your RPC call results in
 // this error, it will result in the same 'status' in your HTTP response. While you can do this
 // for more obscure HTTP failure statuses like "payment required", it's typically a better idea
@@ -47,15 +60,61 @@ func New(status int, messageFormat string, args ...interface{}) RPCError {
 	}
 }
 
+// Status looks for either a Status(), StatusCode(), or Code() method on the error to
+// figure out the most appropriate HTTP status code for it. If the error doesn't have any of
+// those methods then we'll just assume that it is a 500 error.
+func Status(err error) int {
+	var errStatus errorWithStatus
+	if errors.As(err, &errStatus) {
+		return errStatus.Status()
+	}
+
+	var errStatusCode errorWithStatusCode
+	if errors.As(err, &errStatusCode) {
+		return errStatusCode.StatusCode()
+	}
+
+	var errCode errorWithCode
+	if errors.As(err, &errCode) {
+		return errCode.Code()
+	}
+
+	return http.StatusInternalServerError
+}
+
+// Unexpected is a generic 500-style catch-all error for failures you don't know what to do with. This is
+// exactly the same as calling InternalServerError(), just more concise in your code.
+func Unexpected(messageFormat string, args ...interface{}) RPCError {
+	return New(http.StatusInternalServerError, messageFormat, args...)
+}
+
+// IsUnexpected returns true if the underlying HTTP status code of 'err' is 500. This will be true for any
+// error you created using the Unexpected() function.
+func IsUnexpected(err error) bool {
+	return Status(err) == http.StatusInternalServerError
+}
+
 // InternalServerError is a generic 500-style catch-all error for failures you don't know what to do with.
 func InternalServerError(messageFormat string, args ...interface{}) RPCError {
-	return New(http.StatusInternalServerError, messageFormat, args...)
+	return Unexpected(messageFormat, args...)
+}
+
+// IsInternalServiceError returns true if the underlying HTTP status code of 'err' is 500. This will be true for any
+// error you created using the InternalServiceError() function.
+func IsInternalServiceError(err error) bool {
+	return Status(err) == http.StatusInternalServerError
 }
 
 // BadRequest is a 400-style error that indicates that some aspect of the request was either ill-formed
 // or failed validation. This could be an ill-formed function parameter, a bad HTTP body, etc.
 func BadRequest(messageFormat string, args ...interface{}) RPCError {
 	return New(http.StatusBadRequest, messageFormat, args...)
+}
+
+// IsBadRequest returns true if the underlying HTTP status code of 'err' is 400. This will be true for any
+// error you created using the BadRequest() function.
+func IsBadRequest(err error) bool {
+	return Status(err) == http.StatusBadRequest
 }
 
 // BadCredentials is a 401-style error that indicates that the caller either didn't provide credentials
@@ -66,10 +125,22 @@ func BadCredentials(messageFormat string, args ...interface{}) RPCError {
 	return New(http.StatusUnauthorized, messageFormat, args...)
 }
 
+// IsBadCredentials returns true if the underlying HTTP status code of 'err' is 401. This will be true for any
+// error you created using the BadCredentials() function.
+func IsBadCredentials(err error) bool {
+	return Status(err) == http.StatusUnauthorized
+}
+
 // PermissionDenied is a 403-style error that indicates that the caller does not have rights/clearance
 // to perform any part of the operation.
 func PermissionDenied(messageFormat string, args ...interface{}) RPCError {
 	return New(http.StatusForbidden, messageFormat, args...)
+}
+
+// IsPermissionDenied returns true if the underlying HTTP status code of 'err' is 403. This will be true for any
+// error you created using the PermissionDenied() function.
+func IsPermissionDenied(err error) bool {
+	return Status(err) == http.StatusForbidden
 }
 
 // NotFound is a 404-style error that indicates that some record/resource could not be located.
@@ -77,15 +148,33 @@ func NotFound(messageFormat string, args ...interface{}) RPCError {
 	return New(http.StatusNotFound, messageFormat, args...)
 }
 
+// IsNotFound returns true if the underlying HTTP status code of 'err' is 404. This will be true for any
+// error you created using the NotFound() function.
+func IsNotFound(err error) bool {
+	return Status(err) == http.StatusNotFound
+}
+
 // Timeout is a 408-style error that indicates that some operation exceeded its allotted time/deadline.
 func Timeout(messageFormat string, args ...interface{}) RPCError {
 	return New(http.StatusRequestTimeout, messageFormat, args...)
+}
+
+// IsTimeout returns true if the underlying HTTP status code of 'err' is 408. This will be true for any
+// error you created using the Timeout() function.
+func IsTimeout(err error) bool {
+	return Status(err) == http.StatusRequestTimeout
 }
 
 // AlreadyExists is a 409-style error that is used when attempting to create some record/resource, but
 // there is already a duplicate instance in existence.
 func AlreadyExists(messageFormat string, args ...interface{}) RPCError {
 	return New(http.StatusConflict, messageFormat, args...)
+}
+
+// IsAlreadyExists returns true if the underlying HTTP status code of 'err' is 409. This will be true for any
+// error you created using the AlreadyExists() function.
+func IsAlreadyExists(err error) bool {
+	return Status(err) == http.StatusConflict
 }
 
 // Throttled is a 429-style error that indicates that the caller has exceeded the number of requests,
@@ -95,8 +184,20 @@ func Throttled(messageFormat string, args ...interface{}) RPCError {
 	return New(http.StatusTooManyRequests, messageFormat, args...)
 }
 
+// IsThrottled returns true if the underlying HTTP status code of 'err' is 429. This will be true for any
+// error you created using the Throttled() function.
+func IsThrottled(err error) bool {
+	return Status(err) == http.StatusTooManyRequests
+}
+
 // Unavailable is a 503-style error that indicates that some aspect of the server/service is unavailable.
 // This could be something like DB connection failures, some third party service being down, etc.
 func Unavailable(messageFormat string, args ...interface{}) RPCError {
 	return New(http.StatusServiceUnavailable, messageFormat, args...)
+}
+
+// IsUnavailable returns true if the underlying HTTP status code of 'err' is 503. This will be true for any
+// error you created using the Unavailable() function.
+func IsUnavailable(err error) bool {
+	return Status(err) == http.StatusServiceUnavailable
 }

--- a/rpc/errors/errors_test.go
+++ b/rpc/errors/errors_test.go
@@ -3,6 +3,7 @@
 package errors_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/monadicstack/frodo/rpc/errors"
@@ -28,11 +29,81 @@ func (suite *ErrorsSuite) TestNew_wonkyStatus() {
 	suite.assertError(errors.New(9999, ""), 9999, "")
 }
 
+func (suite *ErrorsSuite) TestStatus() {
+	suite.Equal(400, errors.Status(errors.BadRequest("")))
+	suite.Equal(400, errors.Status(errors.New(400, "")))
+
+	suite.Equal(503, errors.Status(errors.Unavailable("")))
+	suite.Equal(503, errors.Status(errors.New(503, "")))
+
+	suite.Equal(500, errors.Status(errors.InternalServerError("")))
+	suite.Equal(500, errors.Status(errors.Unexpected("")))
+	suite.Equal(500, errors.Status(errors.New(500, "")))
+
+	// No status info at all
+	suite.Equal(500, errors.Status(fmt.Errorf("hello")))
+
+	// Non-RPCError examples that do have status values
+	suite.Equal(500, errors.Status(errWithCode{code: 500}))
+	suite.Equal(503, errors.Status(errWithCode{code: 503}))
+	suite.Equal(404, errors.Status(errWithCode{code: 404}))
+	suite.Equal(500, errors.Status(errWithStatusCode{statusCode: 500}))
+	suite.Equal(503, errors.Status(errWithStatusCode{statusCode: 503}))
+	suite.Equal(404, errors.Status(errWithStatusCode{statusCode: 404}))
+}
+
+func (suite *ErrorsSuite) TestUnexpected() {
+	expectedStatus := 500
+	suite.assertError(errors.Unexpected("foo"), expectedStatus, "foo")
+	suite.assertError(errors.Unexpected("%s", "foo"), expectedStatus, "foo")
+	suite.assertError(errors.Unexpected("foo %s %v", "bar", 99), expectedStatus, "foo bar 99")
+}
+
+func (suite *ErrorsSuite) TestUnexpectedASDF() {
+	var err error
+	switch {
+	case errors.IsNotFound(err):
+		// do stuff
+	case err != nil:
+		// do stuff
+	default:
+		// do stuff
+	}
+}
+
+func (suite *ErrorsSuite) TestIsUnexpected() {
+	suite.True(errors.IsUnexpected(errors.Unexpected("foo")))
+	suite.True(errors.IsUnexpected(errors.InternalServerError("foo")))
+	suite.True(errors.IsUnexpected(fmt.Errorf("no status present still 500")))
+	suite.False(errors.IsUnexpected(errors.NotFound("")))
+	suite.False(errors.IsUnexpected(errors.BadCredentials("")))
+
+	// Non-RPCError examples
+	suite.True(errors.IsUnexpected(errWithCode{code: 500}))
+	suite.False(errors.IsUnexpected(errWithCode{code: 400}))
+	suite.True(errors.IsUnexpected(errWithStatusCode{statusCode: 500}))
+	suite.False(errors.IsUnexpected(errWithStatusCode{statusCode: 400}))
+}
+
 func (suite *ErrorsSuite) TestInternalServerError() {
 	expectedStatus := 500
 	suite.assertError(errors.InternalServerError("foo"), expectedStatus, "foo")
 	suite.assertError(errors.InternalServerError("%s", "foo"), expectedStatus, "foo")
 	suite.assertError(errors.InternalServerError("foo %s %v", "bar", 99), expectedStatus, "foo bar 99")
+}
+
+func (suite *ErrorsSuite) TestIsInternalServiceError() {
+	suite.True(errors.IsInternalServiceError(errors.Unexpected("foo")))
+	suite.True(errors.IsInternalServiceError(errors.InternalServerError("foo")))
+	suite.True(errors.IsInternalServiceError(fmt.Errorf("no status present still 500")))
+	suite.False(errors.IsInternalServiceError(errors.NotFound("")))
+	suite.False(errors.IsInternalServiceError(errors.BadCredentials("")))
+
+	// Non-RPCError examples
+	suite.True(errors.IsInternalServiceError(errWithCode{code: 500}))
+	suite.False(errors.IsInternalServiceError(errWithCode{code: 400}))
+	suite.True(errors.IsInternalServiceError(errWithStatusCode{statusCode: 500}))
+	suite.False(errors.IsInternalServiceError(errWithStatusCode{statusCode: 400}))
 }
 
 func (suite *ErrorsSuite) TestBadRequest() {
@@ -42,11 +113,35 @@ func (suite *ErrorsSuite) TestBadRequest() {
 	suite.assertError(errors.BadRequest("foo %s %v", "bar", 99), expectedStatus, "foo bar 99")
 }
 
+func (suite *ErrorsSuite) TestIsBadRequest() {
+	suite.True(errors.IsBadRequest(errors.BadRequest("")))
+	suite.False(errors.IsBadRequest(errors.Unexpected("")))
+	suite.False(errors.IsBadRequest(errors.NotFound("")))
+
+	// Non-RPCError examples
+	suite.True(errors.IsBadRequest(errWithCode{code: 400}))
+	suite.False(errors.IsBadRequest(errWithCode{code: 403}))
+	suite.True(errors.IsBadRequest(errWithStatusCode{statusCode: 400}))
+	suite.False(errors.IsBadRequest(errWithStatusCode{statusCode: 403}))
+}
+
 func (suite *ErrorsSuite) TestBadCredentials() {
 	expectedStatus := 401
 	suite.assertError(errors.BadCredentials("foo"), expectedStatus, "foo")
 	suite.assertError(errors.BadCredentials("%s", "foo"), expectedStatus, "foo")
 	suite.assertError(errors.BadCredentials("foo %s %v", "bar", 99), expectedStatus, "foo bar 99")
+}
+
+func (suite *ErrorsSuite) TestIsBadCredentials() {
+	suite.True(errors.IsBadCredentials(errors.BadCredentials("")))
+	suite.False(errors.IsBadCredentials(errors.Unexpected("")))
+	suite.False(errors.IsBadCredentials(errors.NotFound("")))
+
+	// Non-RPCError examples
+	suite.True(errors.IsBadCredentials(errWithCode{code: 401}))
+	suite.False(errors.IsBadCredentials(errWithCode{code: 403}))
+	suite.True(errors.IsBadCredentials(errWithStatusCode{statusCode: 401}))
+	suite.False(errors.IsBadCredentials(errWithStatusCode{statusCode: 403}))
 }
 
 func (suite *ErrorsSuite) TestPermissionDenied() {
@@ -56,11 +151,35 @@ func (suite *ErrorsSuite) TestPermissionDenied() {
 	suite.assertError(errors.PermissionDenied("foo %s %v", "bar", 99), expectedStatus, "foo bar 99")
 }
 
+func (suite *ErrorsSuite) TestIsPermissionDenied() {
+	suite.True(errors.IsPermissionDenied(errors.PermissionDenied("")))
+	suite.False(errors.IsPermissionDenied(errors.Unexpected("")))
+	suite.False(errors.IsPermissionDenied(errors.NotFound("")))
+
+	// Non-RPCError examples
+	suite.True(errors.IsPermissionDenied(errWithCode{code: 403}))
+	suite.False(errors.IsPermissionDenied(errWithCode{code: 404}))
+	suite.True(errors.IsPermissionDenied(errWithStatusCode{statusCode: 403}))
+	suite.False(errors.IsPermissionDenied(errWithStatusCode{statusCode: 404}))
+}
+
 func (suite *ErrorsSuite) TestNotFound() {
 	expectedStatus := 404
 	suite.assertError(errors.NotFound("foo"), expectedStatus, "foo")
 	suite.assertError(errors.NotFound("%s", "foo"), expectedStatus, "foo")
 	suite.assertError(errors.NotFound("foo %s %v", "bar", 99), expectedStatus, "foo bar 99")
+}
+
+func (suite *ErrorsSuite) TestIsNotFound() {
+	suite.True(errors.IsNotFound(errors.NotFound("")))
+	suite.False(errors.IsNotFound(errors.Unexpected("")))
+	suite.False(errors.IsNotFound(errors.BadRequest("")))
+
+	// Non-RPCError examples
+	suite.True(errors.IsNotFound(errWithCode{code: 404}))
+	suite.False(errors.IsNotFound(errWithCode{code: 401}))
+	suite.True(errors.IsNotFound(errWithStatusCode{statusCode: 404}))
+	suite.False(errors.IsNotFound(errWithStatusCode{statusCode: 401}))
 }
 
 func (suite *ErrorsSuite) TestAlreadyExists() {
@@ -70,11 +189,35 @@ func (suite *ErrorsSuite) TestAlreadyExists() {
 	suite.assertError(errors.AlreadyExists("foo %s %v", "bar", 99), expectedStatus, "foo bar 99")
 }
 
+func (suite *ErrorsSuite) TestIsAlreadyExists() {
+	suite.True(errors.IsAlreadyExists(errors.AlreadyExists("")))
+	suite.False(errors.IsAlreadyExists(errors.Unexpected("")))
+	suite.False(errors.IsAlreadyExists(errors.BadRequest("")))
+
+	// Non-RPCError examples
+	suite.True(errors.IsAlreadyExists(errWithCode{code: 409}))
+	suite.False(errors.IsAlreadyExists(errWithCode{code: 401}))
+	suite.True(errors.IsAlreadyExists(errWithStatusCode{statusCode: 409}))
+	suite.False(errors.IsAlreadyExists(errWithStatusCode{statusCode: 401}))
+}
+
 func (suite *ErrorsSuite) TestTimeout() {
 	expectedStatus := 408
 	suite.assertError(errors.Timeout("foo"), expectedStatus, "foo")
 	suite.assertError(errors.Timeout("%s", "foo"), expectedStatus, "foo")
 	suite.assertError(errors.Timeout("foo %s %v", "bar", 99), expectedStatus, "foo bar 99")
+}
+
+func (suite *ErrorsSuite) TestIsTimeout() {
+	suite.True(errors.IsTimeout(errors.Timeout("")))
+	suite.False(errors.IsTimeout(errors.Unexpected("")))
+	suite.False(errors.IsTimeout(errors.BadRequest("")))
+
+	// Non-RPCError examples
+	suite.True(errors.IsTimeout(errWithCode{code: 408}))
+	suite.False(errors.IsTimeout(errWithCode{code: 401}))
+	suite.True(errors.IsTimeout(errWithStatusCode{statusCode: 408}))
+	suite.False(errors.IsTimeout(errWithStatusCode{statusCode: 401}))
 }
 
 func (suite *ErrorsSuite) TestThrottled() {
@@ -84,11 +227,35 @@ func (suite *ErrorsSuite) TestThrottled() {
 	suite.assertError(errors.Throttled("foo %s %v", "bar", 99), expectedStatus, "foo bar 99")
 }
 
+func (suite *ErrorsSuite) TestIsThrottled() {
+	suite.True(errors.IsThrottled(errors.Throttled("")))
+	suite.False(errors.IsThrottled(errors.Unexpected("")))
+	suite.False(errors.IsThrottled(errors.BadRequest("")))
+
+	// Non-RPCError examples
+	suite.True(errors.IsThrottled(errWithCode{code: 429}))
+	suite.False(errors.IsThrottled(errWithCode{code: 401}))
+	suite.True(errors.IsThrottled(errWithStatusCode{statusCode: 429}))
+	suite.False(errors.IsThrottled(errWithStatusCode{statusCode: 401}))
+}
+
 func (suite *ErrorsSuite) TestUnavailable() {
 	expectedStatus := 503
 	suite.assertError(errors.Unavailable("foo"), expectedStatus, "foo")
 	suite.assertError(errors.Unavailable("%s", "foo"), expectedStatus, "foo")
 	suite.assertError(errors.Unavailable("foo %s %v", "bar", 99), expectedStatus, "foo bar 99")
+}
+
+func (suite *ErrorsSuite) TestIsUnavailable() {
+	suite.True(errors.IsUnavailable(errors.Unavailable("")))
+	suite.False(errors.IsUnavailable(errors.Unexpected("")))
+	suite.False(errors.IsUnavailable(errors.BadRequest("")))
+
+	// Non-RPCError examples
+	suite.True(errors.IsUnavailable(errWithCode{code: 503}))
+	suite.False(errors.IsUnavailable(errWithCode{code: 401}))
+	suite.True(errors.IsUnavailable(errWithStatusCode{statusCode: 503}))
+	suite.False(errors.IsUnavailable(errWithStatusCode{statusCode: 401}))
 }
 
 // assertError checks that both the status and message of the resulting 'err' are what we expect.
@@ -99,4 +266,28 @@ func (suite *ErrorsSuite) assertError(err errors.RPCError, expectedStatus int, e
 
 func TestErrorsSuite(t *testing.T) {
 	suite.Run(t, new(ErrorsSuite))
+}
+
+type errWithCode struct {
+	code int
+}
+
+func (err errWithCode) Code() int {
+	return err.code
+}
+
+func (err errWithCode) Error() string {
+	return ""
+}
+
+type errWithStatusCode struct {
+	statusCode int
+}
+
+func (err errWithStatusCode) StatusCode() int {
+	return err.statusCode
+}
+
+func (err errWithStatusCode) Error() string {
+	return ""
 }


### PR DESCRIPTION
Every `Foo()` error constructor now has an equivalent `IsFoo()` checker function so it's very easy to segment your error handling in a switch statement like so:

```go
switch {
case errors.IsNotFound(err):
    // handle error
case errors.IsPermissionDenied(err):
    // handle error
case err != nil:
    // handle generic error
default:
    // happy path
}
```