### PR TITLE
Nil check on map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-[![Go Report Card](https://goreportcard.com/badge/github.com/monadicstack/frodo)](https://goreportcard.com/report/github.com/monadicstack/frodo)
+[![Go Report Card](https://goreportcard.com/badge/github.com/davidrenne/frodo)](https://goreportcard.com/report/github.com/davidrenne/frodo)
 
 # Frodo
 
 Frodo is a code generator and runtime library that helps
 you write RPC-enabled (micro) services and APIs. It parses
-the interfaces/structs/comments in your service code to 
+the interfaces/structs/comments in your service code to
 generate all of your client/server communication code.
 
-* No .proto files. Your services are just idiomatic Go code.
-* Auto-generate APIs that play nicely with `net/http`, middleware, and other standard library compatible API solutions.  
-* Auto-generate RPC-style clients in multiple languages like Go, JavaScript, Dart, etc.
-* Auto-generate strongly-typed mock implementations of your service for unit testing.
-* Create OpenAPI documentation so others know how to interact with your API (if they can't use the client).
+- No .proto files. Your services are just idiomatic Go code.
+- Auto-generate APIs that play nicely with `net/http`, middleware, and other standard library compatible API solutions.
+- Auto-generate RPC-style clients in multiple languages like Go, JavaScript, Dart, etc.
+- Auto-generate strongly-typed mock implementations of your service for unit testing.
+- Create OpenAPI documentation so others know how to interact with your API (if they can't use the client).
 
 Frodo automates all the boilerplate associated with service
 communication, data marshaling, routing, error handling, etc. You
@@ -27,37 +27,37 @@ with as little fuss as possible.
 
 ## Table of Contents
 
-* [Getting Started](https://github.com/monadicstack/frodo#getting-started)
-* [Example](https://github.com/monadicstack/frodo#example)
-* [Customize HTTP Route, Status, etc](https://github.com/monadicstack/frodo#doc-options-custom-urls-status-etc)
-* [Error Handling](https://github.com/monadicstack/frodo#error-handling)
-* [Middleware](https://github.com/monadicstack/frodo#middleware)
-* [Returning Raw File Data](https://github.com/monadicstack/frodo#returning-raw-file-data)
-* [HTTP Redirects](https://github.com/monadicstack/frodo#http-redirects)
-* [Request Scoped Metadata](https://github.com/monadicstack/frodo#request-scoped-metadata)
-* [Create a JavaScript Client](https://github.com/monadicstack/frodo#creating-a-javascript-client)
-* [Create a Dart/Flutter Client](https://github.com/monadicstack/frodo#creating-a-dartflutter-client)
-* [Authorization](https://github.com/monadicstack/frodo#authorization)
-* [Handling Not Found](https://github.com/monadicstack/frodo#handling-not-found)
-* [Composing Gateways](https://github.com/monadicstack/frodo#composing-gateways)
-* [Mocking Services](https://github.com/monadicstack/frodo#mocking-services)
-* [Generating OpenAPI Documentation](https://github.com/monadicstack/frodo#generate-openapiswagger-documentation-experimental)
-* [Go Generate Support](https://github.com/monadicstack/frodo#go-generate-support)
-* [Bring Your Own Templates](https://github.com/monadicstack/frodo#bring-your-own-templates)
-* [New Service Scaffolding](https://github.com/monadicstack/frodo#create-a-new-service-w-frodo-create)
-* [Why Not gRPC?](https://github.com/monadicstack/frodo#why-not-just-use-grpc) (motivation for this project)
+- [Getting Started](https://github.com/davidrenne/frodo#getting-started)
+- [Example](https://github.com/davidrenne/frodo#example)
+- [Customize HTTP Route, Status, etc](https://github.com/davidrenne/frodo#doc-options-custom-urls-status-etc)
+- [Error Handling](https://github.com/davidrenne/frodo#error-handling)
+- [Middleware](https://github.com/davidrenne/frodo#middleware)
+- [Returning Raw File Data](https://github.com/davidrenne/frodo#returning-raw-file-data)
+- [HTTP Redirects](https://github.com/davidrenne/frodo#http-redirects)
+- [Request Scoped Metadata](https://github.com/davidrenne/frodo#request-scoped-metadata)
+- [Create a JavaScript Client](https://github.com/davidrenne/frodo#creating-a-javascript-client)
+- [Create a Dart/Flutter Client](https://github.com/davidrenne/frodo#creating-a-dartflutter-client)
+- [Authorization](https://github.com/davidrenne/frodo#authorization)
+- [Handling Not Found](https://github.com/davidrenne/frodo#handling-not-found)
+- [Composing Gateways](https://github.com/davidrenne/frodo#composing-gateways)
+- [Mocking Services](https://github.com/davidrenne/frodo#mocking-services)
+- [Generating OpenAPI Documentation](https://github.com/davidrenne/frodo#generate-openapiswagger-documentation-experimental)
+- [Go Generate Support](https://github.com/davidrenne/frodo#go-generate-support)
+- [Bring Your Own Templates](https://github.com/davidrenne/frodo#bring-your-own-templates)
+- [New Service Scaffolding](https://github.com/davidrenne/frodo#create-a-new-service-w-frodo-create)
+- [Why Not gRPC?](https://github.com/davidrenne/frodo#why-not-just-use-grpc) (motivation for this project)
 
 ## Getting Started
 
-*Frodo requires Go 1.16+ as it uses `fs.FS` and `//go:embed` to load templates.*
+_Frodo requires Go 1.16+ as it uses `fs.FS` and `//go:embed` to load templates._
 
 ```shell
-go install github.com/monadicstack/frodo
+go install github.com/davidrenne/frodo
 ```
+
 This will fetch the `frodo` code generation executable as well
 as the runtime libraries that allow your services to
 communicate with each other.
-
 
 ## Example
 
@@ -65,7 +65,7 @@ communicate with each other.
 
 Your first step is to write a .go file that just defines
 the contract for your service; the interface as well as the
-inputs/outputs. 
+inputs/outputs.
 
 ```go
 // calculator_service.go
@@ -98,12 +98,13 @@ type SubResponse struct {
     Result int
 }
 ```
+
 One important detail is that the interface name ends with
 the suffix "Service". This tells Frodo that this is an
 actual service interface and not just some random abstraction
 in your code.
 
-At this point you haven't actually defined *how* this service gets
+At this point you haven't actually defined _how_ this service gets
 this work done; just which operations are available.
 
 We actually have enough for `frodo` to
@@ -140,9 +141,9 @@ At this point, you've just written the same code that you (hopefully)
 would have written even if you weren't using Frodo. Next,
 we want to auto-generate two things:
 
-* A "gateway" that allows an instance of your CalculatorService
+- A "gateway" that allows an instance of your CalculatorService
   to listen for incoming requests (via an HTTP API).
-* A "client" struct that communicates with that API to get work done.
+- A "client" struct that communicates with that API to get work done.
 
 Just run these two commands in a terminal:
 
@@ -155,7 +156,7 @@ frodo client  calculator_service.go
 #### Step 3: Run Your Calculator API Server
 
 Let's fire up an HTTP server on port 9000 that makes your service
-available for consumption (you can choose any port you want, obviously).  
+available for consumption (you can choose any port you want, obviously).
 
 ```go
 package main
@@ -173,6 +174,7 @@ func main() {
     http.ListenAndServe(":9000", gateway)
 }
 ```
+
 Seriously. That's the whole program.
 
 Compile and run it, and your service/API is now ready
@@ -236,10 +238,11 @@ Compile/run this program, and you should see the following output:
 5 + 2 = 7
 5 - 2 = 3
 ```
+
 That's it!
 
 For more examples of how to write services that let Frodo take
-care of the RPC/API boilerplate, take a look in the [example/](https://github.com/monadicstack/frodo/tree/main/example)
+care of the RPC/API boilerplate, take a look in the [example/](https://github.com/davidrenne/frodo/tree/main/example)
 directory of this repo.
 
 ## Doc Options: Custom URLs, Status, etc
@@ -276,7 +279,7 @@ type CalculatorService interface {
 
 This prepends your custom value on every route in the API. It applies
 to the standard `ServiceName.FunctionName` routes as well as custom routes
-as we'll cover in a moment. 
+as we'll cover in a moment.
 
 Your generated API and RPC clients will be auto-wired to use the prefix "v1" under the
 hood, so you don't need to change your code any further. If you want
@@ -325,7 +328,7 @@ package when you encounter a failure case:
 
 ```go
 import (
-    "github.com/monadicstack/frodo/rpc/errors"
+    "github.com/davidrenne/frodo/rpc/errors"
 )
 
 func (svc UserService) Get(ctx context.Context, req *GetRequest) (*GetResponse, error) {
@@ -381,7 +384,7 @@ func NotOnMonday(w http.ResponseWriter, req *http.Request, next http.HandlerFunc
 ```
 
 You might think to yourself... wait a minute; I thought the gateway
-*was* an HTTP handler, so couldn't I just wrap the gateway in middleware
+_was_ an HTTP handler, so couldn't I just wrap the gateway in middleware
 like this?
 
 ```go
@@ -406,7 +409,7 @@ be sure to use `.WithMiddleware()` like in the first example.
 
 Let's say that you're writing `ProfilePictureService`. One of the
 operations you might want is the ability to return the raw JPG data
-for a user's profile picture. You do this the same way that you 
+for a user's profile picture. You do this the same way that you
 handle JSON-based responses; just implement some interfaces so that
 Frodo knows to treat it a little different:
 
@@ -463,7 +466,7 @@ to the URL of your choice:
 // In video_service.go, this implements the Redirector interface.
 type DownloadResponse struct {
     Bucket string
-    Key    string	
+    Key    string
 }
 
 func (res DownloadResponse) Redirect() string {
@@ -479,7 +482,7 @@ func (svc VideoServiceHandler) Download(ctx context.Context, req *DownloadReques
     file := svc.Repo.Get(req.FileID)
     return &DownloadResponse{
         Bucket: file.Bucket,
-        Key:    file.Key, 
+        Key:    file.Key,
     }, nil
 }
 ```
@@ -512,7 +515,7 @@ func (b ServiceB) Bar(ctx context.Context, r *BarRequest) (*BarResponse, error) 
 
     b := 0
     okB = metadata.Value(ctx, "DontPanic", &b)
-    
+
     // At this point:
     // a == ""   okA == false
     // b == 42   okB == true
@@ -545,20 +548,20 @@ which you can include with your frontend codebase. Using it
 should look similar to the Go client we saw earlier:
 
 ```js
-import {CalculatorService} from 'lib/calculator_service.gen.client';
+import { CalculatorService } from "lib/calculator_service.gen.client";
 
 // The service client is a class that exposes all of the
 // operations as 'async' functions that resolve with the
 // result of the service call.
-const service = new CalculatorService('http://localhost:9000');
-const add = await service.Add({A:5, B:2});
-const sub = await service.Sub({A:5, B:2});
+const service = new CalculatorService("http://localhost:9000");
+const add = await service.Add({ A: 5, B: 2 });
+const sub = await service.Sub({ A: 5, B: 2 });
 
 // Should print:
 // Add(5, 2) = 7
 // Sub(5, 2) = 3
-console.info('Add(5, 2) = ' + add.Result)
-console.info('Sub(5, 2) = ' + sub.Result)
+console.info("Add(5, 2) = " + add.Result);
+console.info("Sub(5, 2) = " + sub.Result);
 ```
 
 Another subtle benefit of using Frodo's client is that all of your
@@ -576,13 +579,13 @@ it will just use the window-scoped 'fetch' instance, but you can supply
 your own to the constructor of your service client:
 
 ```js
-const fetch = require('node-fetch');
+const fetch = require("node-fetch");
 
 // Just inject your 'fetch' implementation to the construtor and everything
 // should work exactly the same.
-const service = new CalculatorService('http://localhost:9000', {fetch});
-const add = await service.Add({A:5, B:2});
-const sub = await service.Sub({A:5, B:2});
+const service = new CalculatorService("http://localhost:9000", { fetch });
+const add = await service.Add({ A: 5, B: 2 });
+const sub = await service.Sub({ A: 5, B: 2 });
 ```
 
 ## Creating a Dart/Flutter Client
@@ -623,8 +626,8 @@ to utilize that info.
 
 ```go
 import (
-    "github.com/monadicstack/frodo/rpc/authorization"
-    "github.com/monadicstack/frodo/rpc/errors"
+    "github.com/davidrenne/frodo/rpc/authorization"
+    "github.com/davidrenne/frodo/rpc/errors"
 )
 
 func (a *ServiceA) Hello(ctx contex.Context, req *HelloRequest) (*HelloResponse, error) {
@@ -633,11 +636,12 @@ func (a *ServiceA) Hello(ctx contex.Context, req *HelloRequest) (*HelloResponse,
         return nil, errors.BadCredentials("missing authorization header")
     }
     if auth.String() == "Donny" {
-        return nil, errors.PermissionDenied("you're out of your element")	
+        return nil, errors.PermissionDenied("you're out of your element")
     }
     return &HelloResponse{Text: "Hello"+req.Name}, nil
 }
 ```
+
 Ignore the awful security of hardcoding valid/invalid credentials;
 the value for `auth` should be the value
 of the `Authorization` header on the incoming HTTP request. The whole
@@ -645,10 +649,9 @@ idea is that your business logic exists independent of HTTP-related stuff,
 so Frodo takes that HTTP-provided data and puts it on the context. This
 allows your handler to deal with credentials in a transport-independent fashion.
 
-
 Frodo, however, just makes sure that you have the value that was given. With that
 value in hand, you can feed that to your favorite OAuth2, JWT, or whatever
-library/middleware to do something meaningful with it. 
+library/middleware to do something meaningful with it.
 
 ### Supplying Authorization Credentials
 
@@ -658,7 +661,7 @@ on the context, you can supply them fairly easily:
 
 ```go
 // Supply "Authorization: Token 12345" when calling the Hello endpoint
-auth := authorization.New("Token 12345") 
+auth := authorization.New("Token 12345")
 ctx = authorization.WithHeader(ctx, auth)
 clientA.Hello(ctx, &servicea.HelloRequest{Name: "Bob"})
 ```
@@ -666,7 +669,6 @@ clientA.Hello(ctx, &servicea.HelloRequest{Name: "Bob"})
 This works when you are making the initial call, but to make life easier,
 Frodo will also include that authorization on every other RPC-driven service call you make in that
 request scope:
-
 
 ```go
 func (a *ServiceA) Hello(ctx contex.Context, req *HelloRequest) (*HelloResponse, error) {
@@ -706,9 +708,9 @@ you supply it via an options argument when making your
 service call:
 
 ```js
-const client = new ServiceAClient('...');
-const req = { Name: 'Bob' };
-client.Hello(req, { authorization: 'Token 12345' });
+const client = new ServiceAClient("...");
+const req = { Name: "Bob" };
+client.Hello(req, { authorization: "Token 12345" });
 ```
 
 ### Authorization Using the Dart/Flutter Client
@@ -829,6 +831,7 @@ gateway := rpc.Compose(
 )
 http.listenAndService(":8080", gateway)
 ```
+
 All 3 services will be listening on port 8080, so
 you can access them via their Frodo clients; just give them all the
 same address:
@@ -875,7 +878,7 @@ func TestSomethingThatDependsOnAddFailure(t *testing.T) {
     svc := mocks.MockCalculatorService{
         AddFunc: func(ctx context.Context, req *calc.AddRequest) (*calc.AddResponse, error) {
             return nil, fmt.Errorf("barf...")
-        },	
+        },
     }
 
     // Feed your mock service to the thing you're testing
@@ -929,6 +932,7 @@ type FooService interface {
     // ...
 }
 ```
+
 Now, when you generate your docs the version badge will display "1.2.1".
 
 Not gonna lie... this whole feature is still a work in progress. I've still
@@ -941,7 +945,7 @@ better than no documentation at all, though.
 If you prefer to stick to the standard Go toolchain for generating
 code, you can use `//go:generate` comments to hook Frodo code
 generation into your build process. Here's how you can set up your
-service to generate the gateway, mock service, Go client, and JS client. 
+service to generate the gateway, mock service, Go client, and JS client.
 
 ```go
 import (
@@ -1004,7 +1008,7 @@ lot of that boilerplate for you so that you can get straight
 to solving your customers' problems.
 
 Let's assume that you want to make a new service called
-`UserService`, you can execute any  of the following commands:
+`UserService`, you can execute any of the following commands:
 
 ```shell
 frodo create user
@@ -1031,7 +1035,7 @@ following assets created:
 ```
 
 The service will have a dummy `Create()` function
-just so that there's *something* defined. You should replace
+just so that there's _something_ defined. You should replace
 that with your own functions and implement them to make the service
 do something useful.
 
@@ -1086,40 +1090,40 @@ more time solving your users' problems.
 
 Here are a few conscious deviations from how gRPC does things:
 
-* No proto files or other quirky DSLs to learn. Just write a Go interfaces/structs
+- No proto files or other quirky DSLs to learn. Just write a Go interfaces/structs
   and Frodo will figure out automatically.
-* Setup is as easy as one `go install` to get every feature. gRPC requires you to manually install protoc
+- Setup is as easy as one `go install` to get every feature. gRPC requires you to manually install protoc
   then fetch 3 or 4 grpc-related/Go dependencies, and not all have properly
   adopted Go modules yet.
-* The CLI is much less complex. Even a simple gRPC service
+- The CLI is much less complex. Even a simple gRPC service
   with an API gateway requires around 9 or 10 arguments to `protoc` in order
   to function. Contrast that with `frodo gateway foo/service.go`.
-* If you don't like the CLI, you can hook into `go:generate` instead.
-* In gRPC, the client it generates does not implement the service interface. It's
+- If you don't like the CLI, you can hook into `go:generate` instead.
+- In gRPC, the client it generates does not implement the service interface. It's
   really close but not enough for a strongly typed language like Go. Frodo
   makes it so that clients/gateways both implement your service interface. This
   gives you more flexibility to swap interacting with a local vs remote
   instance of the service w/ no code changes.
-* The RPC layer is just JSON over HTTP. Your frontend can consume
+- The RPC layer is just JSON over HTTP. Your frontend can consume
   your services the exact same way that other backend services do.
-* You've got an entire ecosystem of off-the-shelf solutions for middleware
+- You've got an entire ecosystem of off-the-shelf solutions for middleware
   for logging, security, etc regardless of
   where the request comes from. With gRPC, the rules are
   different if the request came from another service vs
   through your API gateway (e.g. from your frontend).
-* In gRPC, you have to jump through some [crazy hoops](https://grpc-ecosystem.github.io/grpc-gateway/docs/mapping/customizing_your_gateway/) if you 
+- In gRPC, you have to jump through some [crazy hoops](https://grpc-ecosystem.github.io/grpc-gateway/docs/mapping/customizing_your_gateway/) if you
   want anything other than a status of 200 for success 500 for failure.
   With Frodo, you can use idiomatic errors and one-line changes
   to customize this behavior.
-* Since Frodo uses standard-library HTTP, traditional load balancing
+- Since Frodo uses standard-library HTTP, traditional load balancing
   solutions like nginx or your cloud provider's load balancer
   gets the job done. No need to introduce etcd, Consul, Linkerd, Envoy,
   or any other technology into your architecture.
-* Better metadata. Request-scoped metadata in gRPC is basically a map
+- Better metadata. Request-scoped metadata in gRPC is basically a map
   of string values. This forces you to marshal/unmarshal other types yourself.
   Frodo's metadata lets you pass around any type of data you want as
   you hop from service to service and will handle all that noise for you.
-* Frodo has a stronger focus on generated code that is actually
+- Frodo has a stronger focus on generated code that is actually
   readable. If you want to treat Frodo RPC like a black box,
   you can. If you want to peek under the hood, however, you can
   do so with only minimal tears, hopefully.

--- a/cli/create_service.go
+++ b/cli/create_service.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/monadicstack/frodo/generate"
-	"github.com/monadicstack/frodo/parser"
+	"github.com/davidrenne/frodo/generate"
+	"github.com/davidrenne/frodo/parser"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/generate_client.go
+++ b/cli/generate_client.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strings"
 
-	"github.com/monadicstack/frodo/generate"
-	"github.com/monadicstack/frodo/parser"
+	"github.com/davidrenne/frodo/generate"
+	"github.com/davidrenne/frodo/parser"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/generate_docs.go
+++ b/cli/generate_docs.go
@@ -3,8 +3,8 @@ package cli
 import (
 	"log"
 
-	"github.com/monadicstack/frodo/generate"
-	"github.com/monadicstack/frodo/parser"
+	"github.com/davidrenne/frodo/generate"
+	"github.com/davidrenne/frodo/parser"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/generate_gateway.go
+++ b/cli/generate_gateway.go
@@ -3,8 +3,8 @@ package cli
 import (
 	"log"
 
-	"github.com/monadicstack/frodo/generate"
-	"github.com/monadicstack/frodo/parser"
+	"github.com/davidrenne/frodo/generate"
+	"github.com/davidrenne/frodo/parser"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/generate_mock.go
+++ b/cli/generate_mock.go
@@ -3,8 +3,8 @@ package cli
 import (
 	"log"
 
-	"github.com/monadicstack/frodo/generate"
-	"github.com/monadicstack/frodo/parser"
+	"github.com/davidrenne/frodo/generate"
+	"github.com/davidrenne/frodo/parser"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/options.go
+++ b/cli/options.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/monadicstack/frodo/generate"
-	"github.com/monadicstack/frodo/parser"
+	"github.com/davidrenne/frodo/generate"
+	"github.com/davidrenne/frodo/parser"
 )
 
 // templateOption can be embedded on a command request struct to give it the option to supply your

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,24 +7,24 @@ generate all of your client/server communication code.
 
 ## Features
 
-* No .proto files. Your services are just idiomatic Go code.
-* Write Go code that solves a problem and immediately start
+- No .proto files. Your services are just idiomatic Go code.
+- Write Go code that solves a problem and immediately start
   communicating over HTTP/JSON to your frontend and other backend services.
-* Generate robust HTTP APIs/gateways to expose your services. 
-* Ggenerate clients in multiple languages to consume your services
+- Generate robust HTTP APIs/gateways to expose your services.
+- Ggenerate clients in multiple languages to consume your services
   without the need for communication/transport code.
-* Generate complete OpenAPI documentation to describe your
+- Generate complete OpenAPI documentation to describe your
   APIs, operations, schemas, and such.
-* They're just HTTP-based APIs, so deploying to your cloud
-  infrastructure or Kubernetes doesn't require additional complexity. 
-* Insert off-the-shelf middleware functions into your service's flow.
-* Customize RESTful URLS for your API or stick with
+- They're just HTTP-based APIs, so deploying to your cloud
+  infrastructure or Kubernetes doesn't require additional complexity.
+- Insert off-the-shelf middleware functions into your service's flow.
+- Customize RESTful URLS for your API or stick with
   RPC-style URLs; your choice.
-* Easily control HTTP status codes for successes and failures.
-* Automatic data binding so that raw request data is converted
+- Easily control HTTP status codes for successes and failures.
+- Automatic data binding so that raw request data is converted
   into Go structs consumed by your services.
-* Seamlessly pass request-scoped metadata between your services.
-* Embeddable decorators for all of your services so that you can
+- Seamlessly pass request-scoped metadata between your services.
+- Embeddable decorators for all of your services so that you can
   separate service concerns like security and business logic more easily.
 
 ## Motivations (Problems Solved)
@@ -45,8 +45,8 @@ address this problem.
 
 The issue? It adds too much complexity.
 
-There's the 
+There's the
 
 ## Source
 
-[GitHub Repo](https://github.com/monadicstack/frodo)
+[GitHub Repo](https://github.com/davidrenne/frodo)

--- a/example/basic/calc/calculator_service_handler.go
+++ b/example/basic/calc/calculator_service_handler.go
@@ -3,7 +3,7 @@ package calc
 import (
 	"context"
 
-	"github.com/monadicstack/frodo/rpc/errors"
+	"github.com/davidrenne/frodo/rpc/errors"
 )
 
 // CalculatorServiceHandler implements all of the "real" functionality for the CalculatorService. The

--- a/example/basic/calc/cmd/main.go
+++ b/example/basic/calc/cmd/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"net/http"
 
-	"github.com/monadicstack/frodo/example/basic/calc"
-	calcrpc "github.com/monadicstack/frodo/example/basic/calc/gen"
+	"github.com/davidrenne/frodo/example/basic/calc"
+	calcrpc "github.com/davidrenne/frodo/example/basic/calc/gen"
 )
 
 func main() {

--- a/example/basic/calc/gen/calculator_service.gen.client.go
+++ b/example/basic/calc/gen/calculator_service.gen.client.go
@@ -2,7 +2,7 @@
 //
 //   Timestamp: Tue, 10 May 2022 16:23:56 EDT
 //   Source:    calc/calculator_service.go
-//   Generator: https://github.com/monadicstack/frodo
+//   Generator: https://github.com/davidrenne/frodo
 //
 package calc
 
@@ -10,8 +10,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/monadicstack/frodo/example/basic/calc"
-	"github.com/monadicstack/frodo/rpc"
+	"github.com/davidrenne/frodo/example/basic/calc"
+	"github.com/davidrenne/frodo/rpc"
 )
 
 // NewCalculatorServiceClient creates an RPC client that conforms to the CalculatorService interface, but delegates

--- a/example/basic/calc/gen/calculator_service.gen.gateway.go
+++ b/example/basic/calc/gen/calculator_service.gen.gateway.go
@@ -2,7 +2,7 @@
 //
 //   Timestamp: Tue, 10 May 2022 16:23:56 EDT
 //   Source:    calc/calculator_service.go
-//   Generator: https://github.com/monadicstack/frodo
+//   Generator: https://github.com/davidrenne/frodo
 //
 package calc
 
@@ -10,8 +10,8 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/monadicstack/frodo/example/basic/calc"
-	"github.com/monadicstack/frodo/rpc"
+	"github.com/davidrenne/frodo/example/basic/calc"
+	"github.com/davidrenne/frodo/rpc"
 	"github.com/monadicstack/respond"
 )
 

--- a/example/basic/main.go
+++ b/example/basic/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/monadicstack/frodo/example/basic/calc"
-	calcrpc "github.com/monadicstack/frodo/example/basic/calc/gen"
+	"github.com/davidrenne/frodo/example/basic/calc"
+	calcrpc "github.com/davidrenne/frodo/example/basic/calc/gen"
 )
 
 func main() {

--- a/example/compose/main.go
+++ b/example/compose/main.go
@@ -7,13 +7,13 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/monadicstack/frodo/example/basic/calc"
-	calcrpc "github.com/monadicstack/frodo/example/basic/calc/gen"
-	"github.com/monadicstack/frodo/example/multiservice/games"
-	gamesrpc "github.com/monadicstack/frodo/example/multiservice/games/gen"
-	"github.com/monadicstack/frodo/example/multiservice/scores"
-	scoresrpc "github.com/monadicstack/frodo/example/multiservice/scores/gen"
-	"github.com/monadicstack/frodo/rpc"
+	"github.com/davidrenne/frodo/example/basic/calc"
+	calcrpc "github.com/davidrenne/frodo/example/basic/calc/gen"
+	"github.com/davidrenne/frodo/example/multiservice/games"
+	gamesrpc "github.com/davidrenne/frodo/example/multiservice/games/gen"
+	"github.com/davidrenne/frodo/example/multiservice/scores"
+	scoresrpc "github.com/davidrenne/frodo/example/multiservice/scores/gen"
+	"github.com/davidrenne/frodo/rpc"
 )
 
 func main() {

--- a/example/multiservice/games/cmd/main.go
+++ b/example/multiservice/games/cmd/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"net/http"
 
-	"github.com/monadicstack/frodo/example/multiservice/games"
-	gamesrpc "github.com/monadicstack/frodo/example/multiservice/games/gen"
+	"github.com/davidrenne/frodo/example/multiservice/games"
+	gamesrpc "github.com/davidrenne/frodo/example/multiservice/games/gen"
 )
 
 func main() {

--- a/example/multiservice/games/game_handler.go
+++ b/example/multiservice/games/game_handler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/monadicstack/frodo/rpc/errors"
+	"github.com/davidrenne/frodo/rpc/errors"
 )
 
 // GameServiceHandler implements all of the "real" functionality for the GameService.

--- a/example/multiservice/games/gen/game_service.gen.client.go
+++ b/example/multiservice/games/gen/game_service.gen.client.go
@@ -2,7 +2,7 @@
 //
 //   Timestamp: Tue, 10 May 2022 16:25:34 EDT
 //   Source:    games/game_service.go
-//   Generator: https://github.com/monadicstack/frodo
+//   Generator: https://github.com/davidrenne/frodo
 //
 package games
 
@@ -10,8 +10,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/monadicstack/frodo/example/multiservice/games"
-	"github.com/monadicstack/frodo/rpc"
+	"github.com/davidrenne/frodo/example/multiservice/games"
+	"github.com/davidrenne/frodo/rpc"
 )
 
 // NewGameServiceClient creates an RPC client that conforms to the GameService interface, but delegates

--- a/example/multiservice/games/gen/game_service.gen.gateway.go
+++ b/example/multiservice/games/gen/game_service.gen.gateway.go
@@ -2,7 +2,7 @@
 //
 //   Timestamp: Tue, 10 May 2022 16:25:33 EDT
 //   Source:    games/game_service.go
-//   Generator: https://github.com/monadicstack/frodo
+//   Generator: https://github.com/davidrenne/frodo
 //
 package games
 
@@ -10,8 +10,8 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/monadicstack/frodo/example/multiservice/games"
-	"github.com/monadicstack/frodo/rpc"
+	"github.com/davidrenne/frodo/example/multiservice/games"
+	"github.com/davidrenne/frodo/rpc"
 	"github.com/monadicstack/respond"
 )
 

--- a/example/multiservice/games/repo.go
+++ b/example/multiservice/games/repo.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/monadicstack/frodo/rpc/errors"
+	"github.com/davidrenne/frodo/rpc/errors"
 )
 
 // Repo manages access to the data store where we keep game catalog data.

--- a/example/multiservice/main.go
+++ b/example/multiservice/main.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/monadicstack/frodo/example/multiservice/games"
-	gamesrpc "github.com/monadicstack/frodo/example/multiservice/games/gen"
-	"github.com/monadicstack/frodo/example/multiservice/scores"
-	scoresrpc "github.com/monadicstack/frodo/example/multiservice/scores/gen"
+	"github.com/davidrenne/frodo/example/multiservice/games"
+	gamesrpc "github.com/davidrenne/frodo/example/multiservice/games/gen"
+	"github.com/davidrenne/frodo/example/multiservice/scores"
+	scoresrpc "github.com/davidrenne/frodo/example/multiservice/scores/gen"
 )
 
 func main() {

--- a/example/multiservice/scores/cmd/main.go
+++ b/example/multiservice/scores/cmd/main.go
@@ -3,9 +3,9 @@ package main
 import (
 	"net/http"
 
-	games "github.com/monadicstack/frodo/example/multiservice/games/gen"
-	"github.com/monadicstack/frodo/example/multiservice/scores"
-	scoresrpc "github.com/monadicstack/frodo/example/multiservice/scores/gen"
+	games "github.com/davidrenne/frodo/example/multiservice/games/gen"
+	"github.com/davidrenne/frodo/example/multiservice/scores"
+	scoresrpc "github.com/davidrenne/frodo/example/multiservice/scores/gen"
 )
 
 func main() {

--- a/example/multiservice/scores/gen/score_service.gen.client.go
+++ b/example/multiservice/scores/gen/score_service.gen.client.go
@@ -2,7 +2,7 @@
 //
 //   Timestamp: Tue, 10 May 2022 16:25:35 EDT
 //   Source:    scores/score_service.go
-//   Generator: https://github.com/monadicstack/frodo
+//   Generator: https://github.com/davidrenne/frodo
 //
 package scores
 
@@ -10,8 +10,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/monadicstack/frodo/example/multiservice/scores"
-	"github.com/monadicstack/frodo/rpc"
+	"github.com/davidrenne/frodo/example/multiservice/scores"
+	"github.com/davidrenne/frodo/rpc"
 )
 
 // NewScoreServiceClient creates an RPC client that conforms to the ScoreService interface, but delegates

--- a/example/multiservice/scores/gen/score_service.gen.gateway.go
+++ b/example/multiservice/scores/gen/score_service.gen.gateway.go
@@ -2,7 +2,7 @@
 //
 //   Timestamp: Tue, 10 May 2022 16:25:34 EDT
 //   Source:    scores/score_service.go
-//   Generator: https://github.com/monadicstack/frodo
+//   Generator: https://github.com/davidrenne/frodo
 //
 package scores
 
@@ -10,8 +10,8 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/monadicstack/frodo/example/multiservice/scores"
-	"github.com/monadicstack/frodo/rpc"
+	"github.com/davidrenne/frodo/example/multiservice/scores"
+	"github.com/davidrenne/frodo/rpc"
 	"github.com/monadicstack/respond"
 )
 

--- a/example/multiservice/scores/repo.go
+++ b/example/multiservice/scores/repo.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/monadicstack/frodo/rpc/errors"
+	"github.com/davidrenne/frodo/rpc/errors"
 )
 
 // Repo manages access to the data store where we keep high score data.

--- a/example/multiservice/scores/score_handler.go
+++ b/example/multiservice/scores/score_handler.go
@@ -6,8 +6,8 @@ import (
 	"sort"
 	"time"
 
-	"github.com/monadicstack/frodo/example/multiservice/games"
-	"github.com/monadicstack/frodo/rpc/errors"
+	"github.com/davidrenne/frodo/example/multiservice/games"
+	"github.com/davidrenne/frodo/rpc/errors"
 )
 
 // ScoreServiceHandler implements all of the "real" functionality for the ScoreService.

--- a/example/names/cmd/main.go
+++ b/example/names/cmd/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"net/http"
 
-	"github.com/monadicstack/frodo/example/names"
-	namesrpc "github.com/monadicstack/frodo/example/names/gen"
+	"github.com/davidrenne/frodo/example/names"
+	namesrpc "github.com/davidrenne/frodo/example/names/gen"
 )
 
 func main() {

--- a/example/names/gen/name_service.gen.client.dart
+++ b/example/names/gen/name_service.gen.client.dart
@@ -2,7 +2,7 @@
 //
 //   Timestamp: Tue, 10 May 2022 16:18:42 EDT
 //   Source:    example/names/name_service.go
-//   Generator: https://github.com/monadicstack/frodo
+//   Generator: https://github.com/davidrenne/frodo
 //
 import 'dart:async';
 import 'dart:convert';

--- a/example/names/gen/name_service.gen.client.go
+++ b/example/names/gen/name_service.gen.client.go
@@ -2,7 +2,7 @@
 //
 //   Timestamp: Tue, 10 May 2022 16:18:41 EDT
 //   Source:    example/names/name_service.go
-//   Generator: https://github.com/monadicstack/frodo
+//   Generator: https://github.com/davidrenne/frodo
 //
 package names
 
@@ -10,8 +10,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/monadicstack/frodo/example/names"
-	"github.com/monadicstack/frodo/rpc"
+	"github.com/davidrenne/frodo/example/names"
+	"github.com/davidrenne/frodo/rpc"
 )
 
 // NewNameServiceClient creates an RPC client that conforms to the NameService interface, but delegates

--- a/example/names/gen/name_service.gen.client.js
+++ b/example/names/gen/name_service.gen.client.js
@@ -2,240 +2,244 @@
 //
 //   Timestamp: Tue, 10 May 2022 16:18:41 EDT
 //   Source:    example/names/name_service.go
-//   Generator: https://github.com/monadicstack/frodo
+//   Generator: https://github.com/davidrenne/frodo
 //
 /* global fetch,module,window */
-'use strict';
+"use strict";
 
 /**
  * Exposes all of the standard operations for the remote NameService service. These RPC calls
- * will be sent over http(s) to the backend service instances. 
+ * will be sent over http(s) to the backend service instances.
  * NameService performs parsing/processing on a person's name. This is primarily just
  * used as a reference service for integration testing our generated clients.
  */
 class NameServiceClient {
-    _baseURL;
-    _fetch;
-    _authorization;
+  _baseURL;
+  _fetch;
+  _authorization;
 
-    /**
-     * @param {string} baseURL The protocol/host/port used by all API/service
-     *     calls (e.g. "https://some-server:9000")
-     * @param {object} [options]
-     * @param {fetch|*} [options.fetch] Provide a custom implementation for the 'fetch' API. Not
-     *     necessary if running in browser.
-     * @param {string} [options.authorization] Use these credentials in the HTTP Authorization header
-     *      for every request. Only use the client-level authorization when all requests to the
-     *      service should have the same credentials. If you allow multiple users in your system,
-     *      leave this blank and use the authorization option on each request.
-     */
-    constructor(baseURL, {fetch, authorization} = {}) {
-        this._baseURL = trimSlashes(trimSlashes(baseURL) + '/' + trimSlashes(''));
-        this._fetch = fetch || defaultFetch();
-        this._authorization = authorization || '';
+  /**
+   * @param {string} baseURL The protocol/host/port used by all API/service
+   *     calls (e.g. "https://some-server:9000")
+   * @param {object} [options]
+   * @param {fetch|*} [options.fetch] Provide a custom implementation for the 'fetch' API. Not
+   *     necessary if running in browser.
+   * @param {string} [options.authorization] Use these credentials in the HTTP Authorization header
+   *      for every request. Only use the client-level authorization when all requests to the
+   *      service should have the same credentials. If you allow multiple users in your system,
+   *      leave this blank and use the authorization option on each request.
+   */
+  constructor(baseURL, { fetch, authorization } = {}) {
+    this._baseURL = trimSlashes(trimSlashes(baseURL) + "/" + trimSlashes(""));
+    this._fetch = fetch || defaultFetch();
+    this._authorization = authorization || "";
+  }
+
+  /**
+   * Download returns a raw CSV file containing the parsed name.
+   *
+   * @param { DownloadRequest } serviceRequest The input parameters
+   * @param {object} [options]
+   * @param { string } [options.authorization] The HTTP Authorization header value to include
+   *     in the request. This will override any authorization you might have applied when
+   *     constructing this client. Use this in multi-tenant situations where multiple users
+   *     might utilize this service.
+   * @returns {Promise<DownloadResponse>} The JSON-encoded return value of the operation.
+   */
+  async Download(serviceRequest, { authorization } = {}) {
+    if (!serviceRequest) {
+      throw new Error("precondition failed: empty request");
     }
 
-    
-    /**
-     * Download returns a raw CSV file containing the parsed name. 
-     *
-     * @param { DownloadRequest } serviceRequest The input parameters
-     * @param {object} [options]
-     * @param { string } [options.authorization] The HTTP Authorization header value to include
-     *     in the request. This will override any authorization you might have applied when
-     *     constructing this client. Use this in multi-tenant situations where multiple users
-     *     might utilize this service.
-     * @returns {Promise<DownloadResponse>} The JSON-encoded return value of the operation.
-     */
-    async Download(serviceRequest, {authorization} = {}) {
-        if (!serviceRequest) {
-            throw new Error('precondition failed: empty request');
-        }
+    const method = "POST";
+    const route = "/NameService.Download";
+    const url =
+      this._baseURL + "/" + buildRequestPath(method, route, serviceRequest);
+    const fetchOptions = {
+      method: "POST",
+      headers: {
+        Authorization: authorization || this._authorization,
+        Accept: "application/json,*/*",
+        "Content-Type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify(serviceRequest),
+    };
 
-        const method = 'POST';
-        const route = '/NameService.Download';
-        const url = this._baseURL + '/' + buildRequestPath(method, route, serviceRequest);
-        const fetchOptions = {
-            method: 'POST',
-            headers: {
-                'Authorization': authorization || this._authorization,
-                'Accept': 'application/json,*/*',
-                'Content-Type': 'application/json; charset=utf-8',
-            },
-            body: JSON.stringify(serviceRequest),
-        };
+    const response = await this._fetch(url, fetchOptions);
+    return handleResponseRaw(response);
+  }
 
-        const response = await this._fetch(url, fetchOptions);
-        return handleResponseRaw(response);
+  /**
+   * DownloadExt returns a raw CSV file containing the parsed name. This differs from Download
+   * by giving you the "Ext" knob which will let you exercise the content type and disposition
+   * interfaces that Frodo supports for raw responses.
+   *
+   * @param { DownloadExtRequest } serviceRequest The input parameters
+   * @param {object} [options]
+   * @param { string } [options.authorization] The HTTP Authorization header value to include
+   *     in the request. This will override any authorization you might have applied when
+   *     constructing this client. Use this in multi-tenant situations where multiple users
+   *     might utilize this service.
+   * @returns {Promise<DownloadExtResponse>} The JSON-encoded return value of the operation.
+   */
+  async DownloadExt(serviceRequest, { authorization } = {}) {
+    if (!serviceRequest) {
+      throw new Error("precondition failed: empty request");
     }
-    
-    /**
-     * DownloadExt returns a raw CSV file containing the parsed name. This differs from Download 
-     * by giving you the "Ext" knob which will let you exercise the content type and disposition 
-     * interfaces that Frodo supports for raw responses. 
-     *
-     * @param { DownloadExtRequest } serviceRequest The input parameters
-     * @param {object} [options]
-     * @param { string } [options.authorization] The HTTP Authorization header value to include
-     *     in the request. This will override any authorization you might have applied when
-     *     constructing this client. Use this in multi-tenant situations where multiple users
-     *     might utilize this service.
-     * @returns {Promise<DownloadExtResponse>} The JSON-encoded return value of the operation.
-     */
-    async DownloadExt(serviceRequest, {authorization} = {}) {
-        if (!serviceRequest) {
-            throw new Error('precondition failed: empty request');
-        }
 
-        const method = 'POST';
-        const route = '/NameService.DownloadExt';
-        const url = this._baseURL + '/' + buildRequestPath(method, route, serviceRequest);
-        const fetchOptions = {
-            method: 'POST',
-            headers: {
-                'Authorization': authorization || this._authorization,
-                'Accept': 'application/json,*/*',
-                'Content-Type': 'application/json; charset=utf-8',
-            },
-            body: JSON.stringify(serviceRequest),
-        };
+    const method = "POST";
+    const route = "/NameService.DownloadExt";
+    const url =
+      this._baseURL + "/" + buildRequestPath(method, route, serviceRequest);
+    const fetchOptions = {
+      method: "POST",
+      headers: {
+        Authorization: authorization || this._authorization,
+        Accept: "application/json,*/*",
+        "Content-Type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify(serviceRequest),
+    };
 
-        const response = await this._fetch(url, fetchOptions);
-        return handleResponseRaw(response);
+    const response = await this._fetch(url, fetchOptions);
+    return handleResponseRaw(response);
+  }
+
+  /**
+   * FirstName extracts just the first name from a full name string.
+   *
+   * @param { FirstNameRequest } serviceRequest The input parameters
+   * @param {object} [options]
+   * @param { string } [options.authorization] The HTTP Authorization header value to include
+   *     in the request. This will override any authorization you might have applied when
+   *     constructing this client. Use this in multi-tenant situations where multiple users
+   *     might utilize this service.
+   * @returns {Promise<FirstNameResponse>} The JSON-encoded return value of the operation.
+   */
+  async FirstName(serviceRequest, { authorization } = {}) {
+    if (!serviceRequest) {
+      throw new Error("precondition failed: empty request");
     }
-    
-    /**
-     * FirstName extracts just the first name from a full name string. 
-     *
-     * @param { FirstNameRequest } serviceRequest The input parameters
-     * @param {object} [options]
-     * @param { string } [options.authorization] The HTTP Authorization header value to include
-     *     in the request. This will override any authorization you might have applied when
-     *     constructing this client. Use this in multi-tenant situations where multiple users
-     *     might utilize this service.
-     * @returns {Promise<FirstNameResponse>} The JSON-encoded return value of the operation.
-     */
-    async FirstName(serviceRequest, {authorization} = {}) {
-        if (!serviceRequest) {
-            throw new Error('precondition failed: empty request');
-        }
 
-        const method = 'POST';
-        const route = '/NameService.FirstName';
-        const url = this._baseURL + '/' + buildRequestPath(method, route, serviceRequest);
-        const fetchOptions = {
-            method: 'POST',
-            headers: {
-                'Authorization': authorization || this._authorization,
-                'Accept': 'application/json,*/*',
-                'Content-Type': 'application/json; charset=utf-8',
-            },
-            body: JSON.stringify(serviceRequest),
-        };
+    const method = "POST";
+    const route = "/NameService.FirstName";
+    const url =
+      this._baseURL + "/" + buildRequestPath(method, route, serviceRequest);
+    const fetchOptions = {
+      method: "POST",
+      headers: {
+        Authorization: authorization || this._authorization,
+        Accept: "application/json,*/*",
+        "Content-Type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify(serviceRequest),
+    };
 
-        const response = await this._fetch(url, fetchOptions);
-        return handleResponseJSON(response);
+    const response = await this._fetch(url, fetchOptions);
+    return handleResponseJSON(response);
+  }
+
+  /**
+   * LastName extracts just the last name from a full name string.
+   *
+   * @param { LastNameRequest } serviceRequest The input parameters
+   * @param {object} [options]
+   * @param { string } [options.authorization] The HTTP Authorization header value to include
+   *     in the request. This will override any authorization you might have applied when
+   *     constructing this client. Use this in multi-tenant situations where multiple users
+   *     might utilize this service.
+   * @returns {Promise<LastNameResponse>} The JSON-encoded return value of the operation.
+   */
+  async LastName(serviceRequest, { authorization } = {}) {
+    if (!serviceRequest) {
+      throw new Error("precondition failed: empty request");
     }
-    
-    /**
-     * LastName extracts just the last name from a full name string. 
-     *
-     * @param { LastNameRequest } serviceRequest The input parameters
-     * @param {object} [options]
-     * @param { string } [options.authorization] The HTTP Authorization header value to include
-     *     in the request. This will override any authorization you might have applied when
-     *     constructing this client. Use this in multi-tenant situations where multiple users
-     *     might utilize this service.
-     * @returns {Promise<LastNameResponse>} The JSON-encoded return value of the operation.
-     */
-    async LastName(serviceRequest, {authorization} = {}) {
-        if (!serviceRequest) {
-            throw new Error('precondition failed: empty request');
-        }
 
-        const method = 'POST';
-        const route = '/NameService.LastName';
-        const url = this._baseURL + '/' + buildRequestPath(method, route, serviceRequest);
-        const fetchOptions = {
-            method: 'POST',
-            headers: {
-                'Authorization': authorization || this._authorization,
-                'Accept': 'application/json,*/*',
-                'Content-Type': 'application/json; charset=utf-8',
-            },
-            body: JSON.stringify(serviceRequest),
-        };
+    const method = "POST";
+    const route = "/NameService.LastName";
+    const url =
+      this._baseURL + "/" + buildRequestPath(method, route, serviceRequest);
+    const fetchOptions = {
+      method: "POST",
+      headers: {
+        Authorization: authorization || this._authorization,
+        Accept: "application/json,*/*",
+        "Content-Type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify(serviceRequest),
+    };
 
-        const response = await this._fetch(url, fetchOptions);
-        return handleResponseJSON(response);
+    const response = await this._fetch(url, fetchOptions);
+    return handleResponseJSON(response);
+  }
+
+  /**
+   * SortName establishes the "phone book" name for the given full name.
+   *
+   * @param { SortNameRequest } serviceRequest The input parameters
+   * @param {object} [options]
+   * @param { string } [options.authorization] The HTTP Authorization header value to include
+   *     in the request. This will override any authorization you might have applied when
+   *     constructing this client. Use this in multi-tenant situations where multiple users
+   *     might utilize this service.
+   * @returns {Promise<SortNameResponse>} The JSON-encoded return value of the operation.
+   */
+  async SortName(serviceRequest, { authorization } = {}) {
+    if (!serviceRequest) {
+      throw new Error("precondition failed: empty request");
     }
-    
-    /**
-     * SortName establishes the "phone book" name for the given full name. 
-     *
-     * @param { SortNameRequest } serviceRequest The input parameters
-     * @param {object} [options]
-     * @param { string } [options.authorization] The HTTP Authorization header value to include
-     *     in the request. This will override any authorization you might have applied when
-     *     constructing this client. Use this in multi-tenant situations where multiple users
-     *     might utilize this service.
-     * @returns {Promise<SortNameResponse>} The JSON-encoded return value of the operation.
-     */
-    async SortName(serviceRequest, {authorization} = {}) {
-        if (!serviceRequest) {
-            throw new Error('precondition failed: empty request');
-        }
 
-        const method = 'POST';
-        const route = '/NameService.SortName';
-        const url = this._baseURL + '/' + buildRequestPath(method, route, serviceRequest);
-        const fetchOptions = {
-            method: 'POST',
-            headers: {
-                'Authorization': authorization || this._authorization,
-                'Accept': 'application/json,*/*',
-                'Content-Type': 'application/json; charset=utf-8',
-            },
-            body: JSON.stringify(serviceRequest),
-        };
+    const method = "POST";
+    const route = "/NameService.SortName";
+    const url =
+      this._baseURL + "/" + buildRequestPath(method, route, serviceRequest);
+    const fetchOptions = {
+      method: "POST",
+      headers: {
+        Authorization: authorization || this._authorization,
+        Accept: "application/json,*/*",
+        "Content-Type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify(serviceRequest),
+    };
 
-        const response = await this._fetch(url, fetchOptions);
-        return handleResponseJSON(response);
+    const response = await this._fetch(url, fetchOptions);
+    return handleResponseJSON(response);
+  }
+
+  /**
+   * Split separates a first and last name.
+   *
+   * @param { SplitRequest } serviceRequest The input parameters
+   * @param {object} [options]
+   * @param { string } [options.authorization] The HTTP Authorization header value to include
+   *     in the request. This will override any authorization you might have applied when
+   *     constructing this client. Use this in multi-tenant situations where multiple users
+   *     might utilize this service.
+   * @returns {Promise<SplitResponse>} The JSON-encoded return value of the operation.
+   */
+  async Split(serviceRequest, { authorization } = {}) {
+    if (!serviceRequest) {
+      throw new Error("precondition failed: empty request");
     }
-    
-    /**
-     * Split separates a first and last name. 
-     *
-     * @param { SplitRequest } serviceRequest The input parameters
-     * @param {object} [options]
-     * @param { string } [options.authorization] The HTTP Authorization header value to include
-     *     in the request. This will override any authorization you might have applied when
-     *     constructing this client. Use this in multi-tenant situations where multiple users
-     *     might utilize this service.
-     * @returns {Promise<SplitResponse>} The JSON-encoded return value of the operation.
-     */
-    async Split(serviceRequest, {authorization} = {}) {
-        if (!serviceRequest) {
-            throw new Error('precondition failed: empty request');
-        }
 
-        const method = 'POST';
-        const route = '/NameService.Split';
-        const url = this._baseURL + '/' + buildRequestPath(method, route, serviceRequest);
-        const fetchOptions = {
-            method: 'POST',
-            headers: {
-                'Authorization': authorization || this._authorization,
-                'Accept': 'application/json,*/*',
-                'Content-Type': 'application/json; charset=utf-8',
-            },
-            body: JSON.stringify(serviceRequest),
-        };
+    const method = "POST";
+    const route = "/NameService.Split";
+    const url =
+      this._baseURL + "/" + buildRequestPath(method, route, serviceRequest);
+    const fetchOptions = {
+      method: "POST",
+      headers: {
+        Authorization: authorization || this._authorization,
+        Accept: "application/json,*/*",
+        "Content-Type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify(serviceRequest),
+    };
 
-        const response = await this._fetch(url, fetchOptions);
-        return handleResponseJSON(response);
-    }
-    
+    const response = await this._fetch(url, fetchOptions);
+    return handleResponseJSON(response);
+  }
 }
 
 /**
@@ -248,24 +252,24 @@ class NameServiceClient {
  * @returns {string} The fully-populate URL path (e.g. "/user/aCx31s")
  */
 function buildRequestPath(method, path, serviceRequest) {
-    const pathSegments = path.split("/").map(segment => {
-        return segment.startsWith(":")
-            ? attributeValue(serviceRequest, segment.substring(1))
-            : segment;
-    });
-    const resolvedPath = trimSlashes(pathSegments.join("/"));
+  const pathSegments = path.split("/").map((segment) => {
+    return segment.startsWith(":")
+      ? attributeValue(serviceRequest, segment.substring(1))
+      : segment;
+  });
+  const resolvedPath = trimSlashes(pathSegments.join("/"));
 
-    // PUT/POST/PATCH encode the data in the body, so no need to shove it in the query string.
-    if (supportsBody(method)) {
-        return resolvedPath;
-    }
+  // PUT/POST/PATCH encode the data in the body, so no need to shove it in the query string.
+  if (supportsBody(method)) {
+    return resolvedPath;
+  }
 
-    // GET/DELETE/etc will pass all values through the query string.
-    const queryValues = Object.getOwnPropertyNames(serviceRequest)
-        .map(attr => attr + '=' + encodeURLParam(serviceRequest[attr]))
-        .join('&');
+  // GET/DELETE/etc will pass all values through the query string.
+  const queryValues = Object.getOwnPropertyNames(serviceRequest)
+    .map((attr) => attr + "=" + encodeURLParam(serviceRequest[attr]))
+    .join("&");
 
-    return resolvedPath + '?' + queryValues;
+  return resolvedPath + "?" + queryValues;
 }
 
 /**
@@ -275,22 +279,22 @@ function buildRequestPath(method, path, serviceRequest) {
  * @returns {string}
  */
 function encodeURLParam(value) {
-    if (value === null) {
-        return '';
-    }
-    switch (typeof value) {
-    case 'undefined':
-        return '';
-    case 'string':
-    case 'number':
-    case 'boolean':
-        return encodeURIComponent(value);
-    case 'function':
-        return encodeURLParam(value());
+  if (value === null) {
+    return "";
+  }
+  switch (typeof value) {
+    case "undefined":
+      return "";
+    case "string":
+    case "number":
+    case "boolean":
+      return encodeURIComponent(value);
+    case "function":
+      return encodeURLParam(value());
     default:
-        const valueJSON = JSON.stringify(value);
-        return encodeURIComponent(valueJSON);
-    }
+      const valueJSON = JSON.stringify(value);
+      return encodeURIComponent(valueJSON);
+  }
 }
 
 /**
@@ -303,25 +307,24 @@ function encodeURLParam(value) {
  * @returns {*}
  */
 function attributeValue(struct, attributeName) {
-    const normalized = attributeName.toLowerCase();
-    for (const key in struct) {
-        if (key.toLowerCase() === normalized) {
-            return encodeURLParam(struct[key]);
-        }
+  const normalized = attributeName.toLowerCase();
+  for (const key in struct) {
+    if (key.toLowerCase() === normalized) {
+      return encodeURLParam(struct[key]);
     }
-    return null;
+  }
+  return null;
 }
-
 
 /**
  * Accepts the full response data and the request's promise resolve/reject and determines
  * which to invoke. This will also JSON-unmarshal the response data if need be.
  */
 async function handleResponseJSON(response) {
-    if (response.status >= 400) {
-        throw await newError(response);
-    }
-    return await response.json();
+  if (response.status >= 400) {
+    throw await newError(response);
+  }
+  return await response.json();
 }
 
 /**
@@ -333,17 +336,20 @@ async function handleResponseJSON(response) {
  * @returns { {content: Blob, contentType: string, contentFileName: string} }
  */
 async function handleResponseRaw(response) {
-    if (response.status >= 400) {
-        throw await newError(response);
-    }
-    const content = await response.blob();
-    const contentType = response.headers.get('content-type') || 'application/octet-stream';
-    const contentFileName = dispositionFileName(response.headers.get('content-disposition'));
-    return {
-        Content: content,
-        ContentType: contentType,
-        ContentFileName: contentFileName,
-    }
+  if (response.status >= 400) {
+    throw await newError(response);
+  }
+  const content = await response.blob();
+  const contentType =
+    response.headers.get("content-type") || "application/octet-stream";
+  const contentFileName = dispositionFileName(
+    response.headers.get("content-disposition")
+  );
+  return {
+    Content: content,
+    ContentType: contentType,
+    ContentFileName: contentFileName,
+  };
 }
 
 /**
@@ -353,11 +359,11 @@ async function handleResponseRaw(response) {
  * @returns {Promise<GatewayError>}
  */
 async function newError(response) {
-    const responseValue = isJSON(response)
-        ? await response.json()
-        : await response.text();
+  const responseValue = isJSON(response)
+    ? await response.json()
+    : await response.text();
 
-    throw new GatewayError(response.status, parseErrorMessage(responseValue));
+  throw new GatewayError(response.status, parseErrorMessage(responseValue));
 }
 
 /**
@@ -366,45 +372,49 @@ async function newError(response) {
  * @param {string} contentDisposition
  * @returns {string}
  */
-function dispositionFileName(contentDisposition = '') {
-    const fileNameAttrPos = contentDisposition.indexOf('filename=');
-    if (fileNameAttrPos < 0) {
-        return '';
-    }
+function dispositionFileName(contentDisposition = "") {
+  const fileNameAttrPos = contentDisposition.indexOf("filename=");
+  if (fileNameAttrPos < 0) {
+    return "";
+  }
 
-    let fileName = contentDisposition.substring(fileNameAttrPos + 9);
-    fileName = fileName.startsWith('"') ? fileName.substring(1) : fileName;
-    fileName = fileName.endsWith('"') ? fileName.substring(0, fileName.length - 1) : fileName;
-    fileName = fileName.replace(/\\"/g, '"');
-    return fileName;
+  let fileName = contentDisposition.substring(fileNameAttrPos + 9);
+  fileName = fileName.startsWith('"') ? fileName.substring(1) : fileName;
+  fileName = fileName.endsWith('"')
+    ? fileName.substring(0, fileName.length - 1)
+    : fileName;
+  fileName = fileName.replace(/\\"/g, '"');
+  return fileName;
 }
 
 /**
  * Determines whether or not the response has a content type of JSON.
  */
 function isJSON(response) {
-    const contentType = response.headers.get('content-type');
-    return contentType && contentType.toLowerCase().startsWith('application/json');
+  const contentType = response.headers.get("content-type");
+  return (
+    contentType && contentType.toLowerCase().startsWith("application/json")
+  );
 }
 
 /**
-* Looks at the response value and attempts to peel off an error message from it using the standard
-* error JSON structures used by frodo gateways.
-*
-* @param {*} err The error whose raw message you're trying to extract.
-* @returns {string}
-*/
+ * Looks at the response value and attempts to peel off an error message from it using the standard
+ * error JSON structures used by frodo gateways.
+ *
+ * @param {*} err The error whose raw message you're trying to extract.
+ * @returns {string}
+ */
 function parseErrorMessage(err) {
-    if (typeof err === 'string') {
-        return err;
-    }
-    if (typeof err.message !== 'undefined') {
-        return err.message;
-    }
-    if (typeof err.error !== 'undefined') {
-        return err.error;
-    }
-    return JSON.stringify(err);
+  if (typeof err === "string") {
+    return err;
+  }
+  if (typeof err.message !== "undefined") {
+    return err.message;
+  }
+  if (typeof err.error !== "undefined") {
+    return err.error;
+  }
+  return JSON.stringify(err);
 }
 
 /**
@@ -415,7 +425,7 @@ function parseErrorMessage(err) {
  * @returns {boolean}
  */
 function supportsBody(method) {
-    return method === 'POST' || method === 'PUT' || method === 'PATCH';
+  return method === "POST" || method === "PUT" || method === "PATCH";
 }
 
 /**
@@ -425,117 +435,118 @@ function supportsBody(method) {
  * @returns {string}
  */
 function trimSlashes(value) {
-    if (!value) {
-        return "";
-    }
-    while (value.startsWith("/")) {
-        value = value.substring(1);
-    }
-    while (value.endsWith("/")) {
-        value = value.substring(0, value.length - 1);
-    }
-    return value;
+  if (!value) {
+    return "";
+  }
+  while (value.startsWith("/")) {
+    value = value.substring(1);
+  }
+  while (value.endsWith("/")) {
+    value = value.substring(0, value.length - 1);
+  }
+  return value;
 }
 
 /**
-* When you don't supply your own Fetch implementation, this will attempt to use
-* any globally defined ones (typically for use in the browser).
-*
-* @returns {fetch}
-*/
+ * When you don't supply your own Fetch implementation, this will attempt to use
+ * any globally defined ones (typically for use in the browser).
+ *
+ * @returns {fetch}
+ */
 function defaultFetch() {
-    if (typeof fetch === 'undefined') {
-        throw new Error('no global fetch found - if using node, install/import node-fetch');
-    }
+  if (typeof fetch === "undefined") {
+    throw new Error(
+      "no global fetch found - if using node, install/import node-fetch"
+    );
+  }
 
-    const runningInBrowser = typeof window !== 'undefined';
-    return runningInBrowser ? fetch.bind(window) : fetch;
+  const runningInBrowser = typeof window !== "undefined";
+  return runningInBrowser ? fetch.bind(window) : fetch;
 }
 
 /**
-* GatewayError is a rich error type that encapsulates a failure generated by the remote gateway.
-* It captures the server's error message as well as HTTP status so you can properly handle the
-* result in your consumer code.
-*/
+ * GatewayError is a rich error type that encapsulates a failure generated by the remote gateway.
+ * It captures the server's error message as well as HTTP status so you can properly handle the
+ * result in your consumer code.
+ */
 class GatewayError {
-    /**
-    * The HTTP 4XX/5XX status code of the failure.
-    *
-    * @type {number}
-    */
-    status;
+  /**
+   * The HTTP 4XX/5XX status code of the failure.
+   *
+   * @type {number}
+   */
+  status;
 
-    /**
-    * The user-facing message that the server generated for the error.
-    *
-    * @type {string}
-    */
-    message;
+  /**
+   * The user-facing message that the server generated for the error.
+   *
+   * @type {string}
+   */
+  message;
 
-    constructor(status, message) {
-        this.status = status;
-        this.message = message;
-    }
+  constructor(status, message) {
+    this.status = status;
+    this.message = message;
+  }
 
-    toString() {
-        return this.status + ": " + this.message;
-    }
+  toString() {
+    return this.status + ": " + this.message;
+  }
 }
-
 
 /**
  * @typedef { object } SortNameResponse
  * @property { string } [SortName]
-*/
+ */
 /**
  * @typedef { object } FirstNameRequest
  * @property { string } [Name]
-*/
+ */
 /**
  * @typedef { object } LastNameResponse
  * @property { string } [LastName]
-*/
+ */
 /**
  * @typedef { object } SortNameRequest
  * @property { string } [Name]
-*/
+ */
 /**
  * @typedef { object } DownloadExtResponse
-*/
+ */
 /**
  * @typedef { object } SplitResponse
  * @property { string } [FirstName]
  * @property { string } [LastName]
-*/
+ */
 /**
  * @typedef { object } DownloadResponse
-*/
+ */
 /**
  * @typedef { object } LastNameRequest
  * @property { string } [Name]
-*/
+ */
 /**
  * @typedef { object } NameRequest
  * @property { string } [Name]
-*/
+ */
 /**
  * @typedef { object } DownloadExtRequest
  * @property { string } [Name]
  * @property { string } [Ext]
-*/
+ */
 /**
  * @typedef { object } FirstNameResponse
  * @property { string } [FirstName]
-*/
+ */
 /**
  * @typedef { object } SplitRequest
  * @property { string } [Name]
-*/
+ */
 /**
  * @typedef { object } DownloadRequest
  * @property { string } [Name]
-*/
+ */
 
 module.exports = {
-    NameServiceClient,
+  NameServiceClient,
 };

--- a/example/names/gen/name_service.gen.gateway.go
+++ b/example/names/gen/name_service.gen.gateway.go
@@ -2,7 +2,7 @@
 //
 //   Timestamp: Tue, 10 May 2022 16:18:40 EDT
 //   Source:    example/names/name_service.go
-//   Generator: https://github.com/monadicstack/frodo
+//   Generator: https://github.com/davidrenne/frodo
 //
 package names
 
@@ -10,8 +10,8 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/monadicstack/frodo/example/names"
-	"github.com/monadicstack/frodo/rpc"
+	"github.com/davidrenne/frodo/example/names"
+	"github.com/davidrenne/frodo/rpc"
 	"github.com/monadicstack/respond"
 )
 

--- a/example/names/name_service_handler.go
+++ b/example/names/name_service_handler.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"strings"
 
-	"github.com/monadicstack/frodo/rpc/authorization"
-	"github.com/monadicstack/frodo/rpc/errors"
+	"github.com/davidrenne/frodo/rpc/authorization"
+	"github.com/davidrenne/frodo/rpc/errors"
 )
 
 // NameServiceHandler provides the reference implementation of the NameService.

--- a/generate/client_dart_test.go
+++ b/generate/client_dart_test.go
@@ -1,3 +1,4 @@
+//go:build client
 // +build client
 
 package generate_test
@@ -5,10 +6,10 @@ package generate_test
 import (
 	"testing"
 
-	"github.com/monadicstack/frodo/example/names"
-	namesrpc "github.com/monadicstack/frodo/example/names/gen"
-	"github.com/monadicstack/frodo/internal/testext"
-	"github.com/monadicstack/frodo/rpc/errors"
+	"github.com/davidrenne/frodo/example/names"
+	namesrpc "github.com/davidrenne/frodo/example/names/gen"
+	"github.com/davidrenne/frodo/internal/testext"
+	"github.com/davidrenne/frodo/rpc/errors"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/generate/client_go_test.go
+++ b/generate/client_go_test.go
@@ -1,3 +1,4 @@
+//go:build client
 // +build client
 
 package generate_test
@@ -9,11 +10,11 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/monadicstack/frodo/example/names"
-	namesrpc "github.com/monadicstack/frodo/example/names/gen"
-	"github.com/monadicstack/frodo/rpc"
-	"github.com/monadicstack/frodo/rpc/authorization"
-	"github.com/monadicstack/frodo/rpc/errors"
+	"github.com/davidrenne/frodo/example/names"
+	namesrpc "github.com/davidrenne/frodo/example/names/gen"
+	"github.com/davidrenne/frodo/rpc"
+	"github.com/davidrenne/frodo/rpc/authorization"
+	"github.com/davidrenne/frodo/rpc/errors"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/generate/client_node_test.go
+++ b/generate/client_node_test.go
@@ -1,3 +1,4 @@
+//go:build client
 // +build client
 
 package generate_test
@@ -5,10 +6,10 @@ package generate_test
 import (
 	"testing"
 
-	"github.com/monadicstack/frodo/example/names"
-	namesrpc "github.com/monadicstack/frodo/example/names/gen"
-	"github.com/monadicstack/frodo/internal/testext"
-	"github.com/monadicstack/frodo/rpc/errors"
+	"github.com/davidrenne/frodo/example/names"
+	namesrpc "github.com/davidrenne/frodo/example/names/gen"
+	"github.com/davidrenne/frodo/internal/testext"
+	"github.com/davidrenne/frodo/rpc/errors"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/generate/file.go
+++ b/generate/file.go
@@ -12,12 +12,13 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/monadicstack/frodo/internal/naming"
-	"github.com/monadicstack/frodo/parser"
+	"github.com/davidrenne/frodo/internal/naming"
+	"github.com/davidrenne/frodo/parser"
 )
 
-//go:embed templates/*
 // StandardTemplates provides access to all of the code generation templates that Frodo ships with out of the box.
+//
+//go:embed templates/*
 var StandardTemplates embed.FS
 
 // File runs the parsed service context through the given file template, generating the appropriate

--- a/generate/file_test.go
+++ b/generate/file_test.go
@@ -1,3 +1,4 @@
+//go:build unit
 // +build unit
 
 package generate_test
@@ -6,7 +7,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/monadicstack/frodo/generate"
+	"github.com/davidrenne/frodo/generate"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/generate/templates/client.dart.tmpl
+++ b/generate/templates/client.dart.tmpl
@@ -2,7 +2,7 @@
 //
 //   Timestamp: {{ .TimestampString }}
 //   Source:    {{ .Path }}
-//   Generator: https://github.com/monadicstack/frodo
+//   Generator: https://github.com/davidrenne/frodo
 //
 import 'dart:async';
 import 'dart:convert';

--- a/generate/templates/client.go.tmpl
+++ b/generate/templates/client.go.tmpl
@@ -2,7 +2,7 @@
 //
 //   Timestamp: {{ .TimestampString }}
 //   Source:    {{ .Path }}
-//   Generator: https://github.com/monadicstack/frodo
+//   Generator: https://github.com/davidrenne/frodo
 //
 package {{ .OutputPackage.Name }}
 
@@ -10,7 +10,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/monadicstack/frodo/rpc"
+	"github.com/davidrenne/frodo/rpc"
 	"{{ .InputPackage.Import }}"
 )
 

--- a/generate/templates/client.java.tmpl
+++ b/generate/templates/client.java.tmpl
@@ -2,7 +2,7 @@
 //
 //   Timestamp: {{ .TimestampString }}
 //   Source:    {{ .Path }}
-//   Generator: https://github.com/monadicstack/frodo
+//   Generator: https://github.com/davidrenne/frodo
 //
 package {{ .InputPackage.Import | JavaPackage }};
 

--- a/generate/templates/client.js.tmpl
+++ b/generate/templates/client.js.tmpl
@@ -2,7 +2,7 @@
 //
 //   Timestamp: {{ .TimestampString }}
 //   Source:    {{ .Path }}
-//   Generator: https://github.com/monadicstack/frodo
+//   Generator: https://github.com/davidrenne/frodo
 //
 /* global fetch,module,window */
 'use strict';

--- a/generate/templates/create/service_handler.go.tmpl
+++ b/generate/templates/create/service_handler.go.tmpl
@@ -3,7 +3,7 @@ package {{.Package }}
 import (
 	"context"
 
-	"github.com/monadicstack/frodo/rpc/errors"
+	"github.com/davidrenne/frodo/rpc/errors"
 )
 
 // {{ .HandlerName }} implements all of the "real" functionality for the {{ .InterfaceName }}.

--- a/generate/templates/gateway.go.tmpl
+++ b/generate/templates/gateway.go.tmpl
@@ -2,7 +2,7 @@
 //
 //   Timestamp: {{ .TimestampString }}
 //   Source:    {{ .Path }}
-//   Generator: https://github.com/monadicstack/frodo
+//   Generator: https://github.com/davidrenne/frodo
 //
 package {{ .OutputPackage.Name }}
 
@@ -11,7 +11,7 @@ import (
 	"net/http"
 
 	"github.com/monadicstack/respond"
-	"github.com/monadicstack/frodo/rpc"
+	"github.com/davidrenne/frodo/rpc"
 	"{{.InputPackage.Import }}"
 )
 

--- a/generate/templates/mock.go.tmpl
+++ b/generate/templates/mock.go.tmpl
@@ -2,7 +2,7 @@
 //
 //   Timestamp: {{ .TimestampString }}
 //   Source:    {{ .Path }}
-//   Generator: https://github.com/monadicstack/frodo
+//   Generator: https://github.com/davidrenne/frodo
 //
 package {{ .OutputPackage.Name }}
 

--- a/generate/templates/openapi.yml.tmpl
+++ b/generate/templates/openapi.yml.tmpl
@@ -2,7 +2,7 @@
 #
 #   Timestamp: {{ .TimestampString }}
 #   Source:    {{ .Path }}
-#   Generator: https:#github.com/monadicstack/frodo
+#   Generator: https:#github.com/davidrenne/frodo
 #
 openapi: 3.0.0
 info:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/monadicstack/frodo
+module github.com/davidrenne/frodo
 
 go 1.16
 

--- a/internal/naming/naming_test.go
+++ b/internal/naming/naming_test.go
@@ -1,3 +1,4 @@
+//go:build unit
 // +build unit
 
 package naming_test
@@ -5,7 +6,7 @@ package naming_test
 import (
 	"testing"
 
-	"github.com/monadicstack/frodo/internal/naming"
+	"github.com/davidrenne/frodo/internal/naming"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/internal/testext/client.go
+++ b/internal/testext/client.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/monadicstack/frodo/rpc/errors"
+	"github.com/davidrenne/frodo/rpc/errors"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -49,10 +49,10 @@ func (suite *ExternalClientSuite) StopService() {
 // 'out' parameter so that you can also run custom checks to fire after the decoding is complete to ensure that
 // the actual output value is what you expect.
 //
-//     response := calc.AddResponse{}
-//     suite.ExpectPass(output, 0, &response, func() {
-//         suite.Equal(12, response.Result)
-//     })
+//	response := calc.AddResponse{}
+//	suite.ExpectPass(output, 0, &response, func() {
+//	    suite.Equal(12, response.Result)
+//	})
 func (suite *ExternalClientSuite) ExpectPass(results ClientTestResults, lineIndex int, out interface{}, additionalChecks ...func()) {
 	result := results[lineIndex]
 	suite.Require().Equal(true, result.Pass, "Client Line %d: Call failed when it should have passed", lineIndex)
@@ -67,10 +67,10 @@ func (suite *ExternalClientSuite) ExpectPass(results ClientTestResults, lineInde
 // 'out' parameter so that you can also run custom checks to fire after the decoding is complete to ensure that
 // the actual output error is what you expect.
 //
-//     err := errors.RPCError{}
-//     suite.ExpectFail(output, 0, &response, func() {
-//         suite.Contains(err.Message, "divide by zero")
-//     })
+//	err := errors.RPCError{}
+//	suite.ExpectFail(output, 0, &response, func() {
+//	    suite.Contains(err.Message, "divide by zero")
+//	})
 func (suite *ExternalClientSuite) ExpectFail(results ClientTestResults, lineIndex int, out interface{}, additionChecks ...func()) {
 	result := results[lineIndex]
 	suite.Require().Equal(false, result.Pass, "Client Line %d: Call passed when it should have failed", lineIndex)
@@ -85,10 +85,10 @@ func (suite *ExternalClientSuite) ExpectFail(results ClientTestResults, lineInde
 // RPCError such that there's a 'status' and 'message' field and that the status is equivalent to the one you supply.
 // This is a convenience on top of ExpectFail to reduce verbosity.
 //
-//     // Assumes the first case failed w/ a 403 status, the second w/ a 502, and the last with a 500.
-//     suite.ExpectFailStatus(output, 0, 403)
-//     suite.ExpectFailStatus(output, 1, 502)
-//     suite.ExpectFailStatus(output, 2, 500)
+//	// Assumes the first case failed w/ a 403 status, the second w/ a 502, and the last with a 500.
+//	suite.ExpectFailStatus(output, 0, 403)
+//	suite.ExpectFailStatus(output, 1, 502)
+//	suite.ExpectFailStatus(output, 2, 500)
 func (suite *ExternalClientSuite) ExpectFailStatus(results ClientTestResults, lineIndex int, status int) {
 	err := errors.RPCError{}
 	suite.ExpectFail(results, lineIndex, &err, func() {
@@ -111,11 +111,11 @@ func RunClientTest(executable string, args ...string) (ClientTestResults, error)
 // interaction in the test case behaved. Here is a sample output of a runner that performed 5 client calls to
 // the backend service; 3 that passed and 2 that failed.
 //
-//     OK {"result": 5}
-//     FAIL {"message": "divide by zero", "status": 400}
-//     OK {"result": 3.14}
-//     OK {"result": 10, "remainder": 2}
-//     FAIL {"message": "overflow", "status": 400}
+//	OK {"result": 5}
+//	FAIL {"message": "divide by zero", "status": 400}
+//	OK {"result": 3.14}
+//	OK {"result": 10, "remainder": 2}
+//	FAIL {"message": "overflow", "status": 400}
 //
 // All language runners should output in this format for this to work. It's a convention that allows us to build
 // assertions in Go regardless of how the target language does its work.

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/monadicstack/frodo/cli"
+	"github.com/davidrenne/frodo/cli"
 	"github.com/spf13/cobra"
 )
 

--- a/parser/context.go
+++ b/parser/context.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/monadicstack/frodo/internal/naming"
+	"github.com/davidrenne/frodo/internal/naming"
 	"golang.org/x/tools/go/packages"
 )
 

--- a/parser/context_test.go
+++ b/parser/context_test.go
@@ -1,3 +1,4 @@
+//go:build unit
 // +build unit
 
 package parser_test
@@ -8,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/monadicstack/frodo/parser"
+	"github.com/davidrenne/frodo/parser"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -15,8 +15,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/monadicstack/frodo/internal/implements"
-	"github.com/monadicstack/frodo/internal/naming"
+	"github.com/davidrenne/frodo/internal/implements"
+	"github.com/davidrenne/frodo/internal/naming"
 	"golang.org/x/mod/modfile"
 	"golang.org/x/tools/go/packages"
 )

--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -1,3 +1,4 @@
+//go:build unit
 // +build unit
 
 package parser_test
@@ -5,7 +6,7 @@ package parser_test
 import (
 	"testing"
 
-	"github.com/monadicstack/frodo/parser"
+	"github.com/davidrenne/frodo/parser"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/parser/testdata/fieldtypes/service.go
+++ b/parser/testdata/fieldtypes/service.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/monadicstack/frodo/parser/testdata"
+	"github.com/davidrenne/frodo/parser/testdata"
 	"github.com/monadicstack/respond"
 )
 

--- a/rpc/authorization/authoriation_test.go
+++ b/rpc/authorization/authoriation_test.go
@@ -1,3 +1,4 @@
+//go:build unit
 // +build unit
 
 package authorization_test
@@ -6,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/monadicstack/frodo/rpc/authorization"
+	"github.com/davidrenne/frodo/rpc/authorization"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/rpc/binding.go
+++ b/rpc/binding.go
@@ -9,9 +9,9 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/davidrenne/frodo/internal/reflection"
+	"github.com/davidrenne/frodo/rpc/errors"
 	"github.com/dimfeld/httptreemux/v5"
-	"github.com/monadicstack/frodo/internal/reflection"
-	"github.com/monadicstack/frodo/rpc/errors"
 )
 
 // Binder performs the work of taking all meaningful values from an incoming request (body,
@@ -40,15 +40,15 @@ func WithBinder(binder Binder) GatewayOption {
 // JSON so that we can use the standard library's JSON package to unmarshal that data onto your out value.
 // For example, let's assume that we have the following query string:
 //
-//     ?first=Bob&last=Smith&age=39&address.city=Seattle&enabled=true
+//	?first=Bob&last=Smith&age=39&address.city=Seattle&enabled=true
 //
 // The jsonBinder will first create 5 separate JSON objects:
 //
-//     { "first": "Bob" }
-//     { "last": "Smith" }
-//     { "age": 39 }
-//     { "address": { "city": "Seattle" } }     <-- notice how we handle nested values separated by "."
-//     { "enabled": true }
+//	{ "first": "Bob" }
+//	{ "last": "Smith" }
+//	{ "age": 39 }
+//	{ "address": { "city": "Seattle" } }     <-- notice how we handle nested values separated by "."
+//	{ "enabled": true }
 //
 // After generating each value, the jsonBinder will feed the massaged JSON to a 'json.Decoder' and standard
 // JSON marshaling rules will overlay each one onto your 'out' value.

--- a/rpc/binding_bench_test.go
+++ b/rpc/binding_bench_test.go
@@ -1,3 +1,4 @@
+//go:build unit
 // +build unit
 
 package rpc_test
@@ -8,8 +9,8 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/davidrenne/frodo/rpc"
 	"github.com/dimfeld/httptreemux/v5"
-	"github.com/monadicstack/frodo/rpc"
 )
 
 func BenchmarkJsonBinder_Bind(b *testing.B) {

--- a/rpc/binding_test.go
+++ b/rpc/binding_test.go
@@ -1,3 +1,4 @@
+//go:build unit
 // +build unit
 
 package rpc_test
@@ -11,8 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/davidrenne/frodo/rpc"
 	"github.com/dimfeld/httptreemux/v5"
-	"github.com/monadicstack/frodo/rpc"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -13,11 +13,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/monadicstack/frodo/internal/naming"
-	"github.com/monadicstack/frodo/internal/reflection"
-	"github.com/monadicstack/frodo/rpc/authorization"
-	"github.com/monadicstack/frodo/rpc/errors"
-	"github.com/monadicstack/frodo/rpc/metadata"
+	"github.com/davidrenne/frodo/internal/naming"
+	"github.com/davidrenne/frodo/internal/reflection"
+	"github.com/davidrenne/frodo/rpc/authorization"
+	"github.com/davidrenne/frodo/rpc/errors"
+	"github.com/davidrenne/frodo/rpc/metadata"
 )
 
 // NewClient constructs the RPC client that does the "heavy lifting" when communicating

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -1,3 +1,4 @@
+//go:build unit
 // +build unit
 
 package rpc_test
@@ -13,9 +14,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/monadicstack/frodo/rpc"
-	"github.com/monadicstack/frodo/rpc/authorization"
-	"github.com/monadicstack/frodo/rpc/metadata"
+	"github.com/davidrenne/frodo/rpc"
+	"github.com/davidrenne/frodo/rpc/authorization"
+	"github.com/davidrenne/frodo/rpc/metadata"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/rpc/errors/errors_test.go
+++ b/rpc/errors/errors_test.go
@@ -1,3 +1,4 @@
+//go:build unit
 // +build unit
 
 package errors_test
@@ -6,7 +7,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/monadicstack/frodo/rpc/errors"
+	"github.com/davidrenne/frodo/rpc/errors"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/rpc/gateway.go
+++ b/rpc/gateway.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/davidrenne/frodo/rpc/authorization"
+	"github.com/davidrenne/frodo/rpc/metadata"
 	"github.com/dimfeld/httptreemux/v5"
-	"github.com/monadicstack/frodo/rpc/authorization"
-	"github.com/monadicstack/frodo/rpc/metadata"
 	"github.com/monadicstack/respond"
 	"github.com/urfave/negroni"
 )
@@ -127,7 +127,7 @@ func (gw Gateway) registerOptions(path string) {
 func (gw Gateway) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// Why the negroni response writer?
 	//
-	//     https://github.com/monadicstack/frodo/issues/50
+	//     https://github.com/davidrenne/frodo/issues/50
 	//
 	// Since negroni is basically the de facto HTTP middleware for go, I want to support their
 	// out-of-the-box functions as much as possible. Unfortunately their logger middleware will
@@ -293,16 +293,16 @@ func (gw CompositeGateway) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 // development. Rather than starting/stopping 20 different processes, you can run all of your services in a single
 // server process:
 //
-//     userGateway := users.NewUserServiceGateway(userService)
-//     groupGateway := groups.NewGroupServiceGateway(groupService)
-//     projectGateway := projects.NewProjectServiceGateway(projectService)
+//	userGateway := users.NewUserServiceGateway(userService)
+//	groupGateway := groups.NewGroupServiceGateway(groupService)
+//	projectGateway := projects.NewProjectServiceGateway(projectService)
 //
-//     gateway := rpc.Compose(
-//         userGateway,
-//         groupGateway,
-//         projectGateway,
-//     )
-//     http.listenAndService(":8080", gateway)
+//	gateway := rpc.Compose(
+//	    userGateway,
+//	    groupGateway,
+//	    projectGateway,
+//	)
+//	http.listenAndService(":8080", gateway)
 //
 // This will preserve all of the original gateways as well. Now you'll just have a "master" gateway that contains
 // all of the routes/endpoints from all of the services.

--- a/rpc/gateway_test.go
+++ b/rpc/gateway_test.go
@@ -1,3 +1,4 @@
+//go:build unit
 // +build unit
 
 package rpc_test
@@ -13,11 +14,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/davidrenne/frodo/internal/testext"
+	"github.com/davidrenne/frodo/rpc"
+	"github.com/davidrenne/frodo/rpc/authorization"
+	"github.com/davidrenne/frodo/rpc/metadata"
 	"github.com/dimfeld/httptreemux/v5"
-	"github.com/monadicstack/frodo/internal/testext"
-	"github.com/monadicstack/frodo/rpc"
-	"github.com/monadicstack/frodo/rpc/authorization"
-	"github.com/monadicstack/frodo/rpc/metadata"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/rpc/metadata/values.go
+++ b/rpc/metadata/values.go
@@ -16,7 +16,7 @@ import (
 	"encoding/json"
 	"log"
 
-	"github.com/monadicstack/frodo/internal/reflection"
+	"github.com/davidrenne/frodo/internal/reflection"
 )
 
 // The context value entry for our metadata map.

--- a/rpc/metadata/values.go
+++ b/rpc/metadata/values.go
@@ -151,7 +151,9 @@ func WithValue(ctx context.Context, key string, value interface{}) context.Conte
 	// At some point I would love for this to be not rely on side-effects and mutating a map. I'd
 	// rather that adding new values create copies of the metadata structure so it's more thread
 	// safe like normal context values. But this will work for now...
-	meta[key] = valuesEntry{Value: value}
+	if meta != nil {
+		meta[key] = valuesEntry{Value: value}
+	}
 	return ctx
 }
 

--- a/rpc/metadata/values_test.go
+++ b/rpc/metadata/values_test.go
@@ -1,3 +1,4 @@
+//go:build unit
 // +build unit
 
 package metadata_test
@@ -6,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/monadicstack/frodo/rpc/metadata"
+	"github.com/davidrenne/frodo/rpc/metadata"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/rpc/middleware_test.go
+++ b/rpc/middleware_test.go
@@ -1,3 +1,4 @@
+//go:build unit
 // +build unit
 
 package rpc_test
@@ -6,7 +7,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/monadicstack/frodo/rpc"
+	"github.com/davidrenne/frodo/rpc"
 	"github.com/stretchr/testify/suite"
 )
 


### PR DESCRIPTION
If a user is using context.Background() with an internal gen client in golang as well as using a custom middleware that injects more context, the map is nil and attempts to assign to a nil map.  ok was true, yet still meta was nil in my use case.

Here is my middleware that causes this when an internally used gen client invokes an RPC, it panics on this line without the nil check.

```
func PassRemoteAddr(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
	ctx := metadata.WithValue(req.Context(), "RemoteAddr", req.RemoteAddr)
	req = req.Clone(ctx)
	next(w, req)
}
```