### PR TITLE
Create meta if meta is nil

### DIFF
--- a/rpc/metadata/values.go
+++ b/rpc/metadata/values.go
@@ -143,7 +143,7 @@ func WithValue(ctx context.Context, key string, value interface{}) context.Conte
 		return ctx
 	}
 	meta, ok := ctx.Value(contextKey{}).(Values)
-	if !ok {
+	if !ok || meta == nil {
 		meta = Values{}
 		ctx = WithValues(ctx, meta)
 	}


### PR DESCRIPTION
There is a case where ok is true, yet meta comes back as nil and therefore gets `assignment to entry in nil map`

If a user is using context.Background() with an internal gen client in golang as well as using a custom middleware that injects more context, the map is nil and attempts to assign to a nil map. ok was true, yet still meta was nil in my use case.

Here is my middleware that causes this when an internally used gen client invokes an RPC, it panics on this line without the nil check.

```
func PassRemoteAddr(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
	ctx := metadata.WithValue(req.Context(), "RemoteAddr", req.RemoteAddr)
	req = req.Clone(ctx)
	next(w, req)
}
```

In my davidrenne fork, I just completely forked the package with a if meta != nil wrapped around the map assignment, but I think it would be better to just to fall into your !ok condition if meta comes back as nil as well to recreate meta so the assignment will never hit this case.